### PR TITLE
feat(templating-resources): add innerHTML attached behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,10 @@ import {Repeat} from './repeat';
 import {Show} from './show';
 import {SelectedItem} from './selected-item';
 import {GlobalBehavior} from './global-behavior';
+import {InnerHTML} from './inner-html';
 
 function install(aurelia){
-  aurelia.withResources([Show, If, Repeat, Compose, SelectedItem, GlobalBehavior]);
+  aurelia.withResources([Show, If, Repeat, Compose, SelectedItem, GlobalBehavior, InnerHTML]);
 }
 
 export {
@@ -14,6 +15,7 @@ export {
   If,
   Repeat,
   Show,
+  InnerHTML,
   SelectedItem,
   GlobalBehavior,
   install

--- a/src/inner-html.js
+++ b/src/inner-html.js
@@ -1,0 +1,35 @@
+import {Behavior} from 'aurelia-templating';
+
+export class InnerHTML {
+  static metadata(){
+    return Behavior
+    .attachedBehavior('inner-html')
+    .withOptions().and( x => {
+      x.withProperty('sanitizer', 'sanitizerChanged');
+      x.withProperty('value', 'valueChanged');
+    });
+  }
+
+  static inject() { return [Element]; }
+  constructor(element) {
+    this.element = element;
+  }
+
+  valueChanged(text){
+    if(this.sanitizer) {
+      text = this.sanitizer(text);
+    }
+    else {
+      var SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
+
+      while (SCRIPT_REGEX.test(text)) {
+        text = text.replace(SCRIPT_REGEX, "");
+      }
+    }
+    this.element.innerHTML = text;
+  }
+
+  sanitizerChanged(newSanitizer) {
+    this.sanitizer = newSanitizer;
+  }
+}

--- a/src/inner-html.js
+++ b/src/inner-html.js
@@ -5,31 +5,37 @@ export class InnerHTML {
     return Behavior
     .attachedBehavior('inner-html')
     .withOptions().and( x => {
-      x.withProperty('sanitizer', 'sanitizerChanged');
       x.withProperty('value', 'valueChanged');
+      x.withProperty('sanitizer');
     });
   }
 
   static inject() { return [Element]; }
   constructor(element) {
     this.element = element;
+    this.sanitizer = InnerHTML.defaultSanitizer;
+  }
+
+  static defaultSanitizer(text) {
+    var SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
+
+    while (SCRIPT_REGEX.test(text)) {
+      text = text.replace(SCRIPT_REGEX, "");
+    }
+
+    return text;
+  }
+
+  bind(bindingContext) {
+    this.setElementInnerHTML(this.value);
   }
 
   valueChanged(text){
-    if(this.sanitizer) {
-      text = this.sanitizer(text);
-    }
-    else {
-      var SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
-
-      while (SCRIPT_REGEX.test(text)) {
-        text = text.replace(SCRIPT_REGEX, "");
-      }
-    }
-    this.element.innerHTML = text;
+    this.setElementInnerHTML(text);
   }
 
-  sanitizerChanged(newSanitizer) {
-    this.sanitizer = newSanitizer;
+  setElementInnerHTML(text) {
+    text = this.sanitizer(text);
+    this.element.innerHTML = text;
   }
 }

--- a/test/inner-html.spec.js
+++ b/test/inner-html.spec.js
@@ -1,14 +1,20 @@
 import {InnerHTML} from '../src/inner-html';
 
-describe('An InnerHTML testing suite', () => {
-  var element, behavior;
+describe('The InnerHTML behavior', () => {
+  var element, behavior, defaultSanitizer;
 
   beforeEach(() => {
+    defaultSanitizer = InnerHTML.defaultSanitizer;
+
     element = {
       innerHTML: ''
     };
 
     behavior = new InnerHTML(element);
+  });
+
+  afterEach(() => {
+    InnerHTML.defaultSanitizer = defaultSanitizer;
   });
 
   it('should set the innerHTML property', () => {
@@ -17,10 +23,23 @@ describe('An InnerHTML testing suite', () => {
     expect(element.innerHTML).toBe('test');
   });
 
+  it('should call a global custom sanitizer', () => {
+
+    var mockSanitizer = jasmine.createSpy('sanitizer spy');
+
+    InnerHTML.defaultSanitizer = mockSanitizer;
+
+    behavior = new InnerHTML(element);
+
+    behavior.valueChanged('test');
+
+    expect(mockSanitizer).toHaveBeenCalled();
+  });
+
   it('should call a custom sanitizer', () => {
     var mockSanitizer = jasmine.createSpy('sanitizer spy');
 
-    behavior.sanitizerChanged(mockSanitizer);
+    behavior.sanitizer = mockSanitizer;
 
     behavior.valueChanged('test');
 
@@ -36,7 +55,7 @@ describe('An InnerHTML testing suite', () => {
   it('should pass the text to be sanitized', () => {
     var mockSanitizer = jasmine.createSpy('sanitizer spy');
 
-    behavior.sanitizerChanged(mockSanitizer);
+    behavior.sanitizer = mockSanitizer;
 
     behavior.valueChanged('test');
 
@@ -46,7 +65,7 @@ describe('An InnerHTML testing suite', () => {
   it('should set innerHTML to the output of the sanitizer', () => {
     var mockSanitizer = jasmine.createSpy('sanitizer spy').and.returnValue('output');
 
-    behavior.sanitizerChanged(mockSanitizer);
+    behavior.sanitizer = mockSanitizer;
 
     behavior.valueChanged('test');
 

--- a/test/inner-html.spec.js
+++ b/test/inner-html.spec.js
@@ -1,0 +1,55 @@
+import {InnerHTML} from '../src/inner-html';
+
+describe('An InnerHTML testing suite', () => {
+  var element, behavior;
+
+  beforeEach(() => {
+    element = {
+      innerHTML: ''
+    };
+
+    behavior = new InnerHTML(element);
+  });
+
+  it('should set the innerHTML property', () => {
+    behavior.valueChanged('test');
+
+    expect(element.innerHTML).toBe('test');
+  });
+
+  it('should call a custom sanitizer', () => {
+    var mockSanitizer = jasmine.createSpy('sanitizer spy');
+
+    behavior.sanitizerChanged(mockSanitizer);
+
+    behavior.valueChanged('test');
+
+    expect(mockSanitizer).toHaveBeenCalled();
+  });
+
+  it('should sanitize script tags by default', () => {
+    behavior.valueChanged('test<script>var foo = "nefarious code"</script>');
+
+    expect(element.innerHTML).toBe('test');
+  });
+
+  it('should pass the text to be sanitized', () => {
+    var mockSanitizer = jasmine.createSpy('sanitizer spy');
+
+    behavior.sanitizerChanged(mockSanitizer);
+
+    behavior.valueChanged('test');
+
+    expect(mockSanitizer).toHaveBeenCalledWith('test');
+  });
+
+  it('should set innerHTML to the output of the sanitizer', () => {
+    var mockSanitizer = jasmine.createSpy('sanitizer spy').and.returnValue('output');
+
+    behavior.sanitizerChanged(mockSanitizer);
+
+    behavior.valueChanged('test');
+
+    expect(element.innerHTML).toBe('output');
+  });
+});


### PR DESCRIPTION
Initial implementation of the behavior. Ready for comments.

I implemented it per these instructions from @EisenbergEffect :
```
1. You can go ahead and implement it using the options syntax. Name the behavior inner-html.
2. So, it should be used like this: inner-html="value.bind: some.prop; sanitizer.call: mySanitizationFunction”
3. The sanitizer should be optional. If it isn’t provided it should fallback to a default santizer.
4. The default sanitizer should also be configurable.
5. Hopefully we can also support the short form: inner-html.bind=“some.prop". I’m not sure if that will work with options configured or not. I might need to do a fix for that, but you can get started on the work and I can try to fix that later.
```

This implementation addresses items 1, 2, and 3. I will need further guidance on 4.