### PR TITLE
fix (templating-resource): case sensitive jquery plugin names

### DIFF
--- a/src/global-behavior.js
+++ b/src/global-behavior.js
@@ -1,4 +1,5 @@
 import {Behavior} from 'aurelia-templating';
+import * as LogManager from 'aurelia-logging';
 
 export class GlobalBehavior {
   static metadata(){ 
@@ -68,7 +69,17 @@ GlobalBehavior.handlers = {
     bind(behavior, element, command){
       var settings = GlobalBehavior.createSettingsFromBehavior(behavior);
       var pluginName = GlobalBehavior.jQueryPlugins[command] || command;
-      behavior.plugin = window.jQuery(element)[pluginName](settings);
+      var jqueryElement = window.jQuery(element);
+
+      if(!jqueryElement[pluginName]){
+        LogManager.getLogger('templating-resources').warn(`Could not find the jQuery plugin ${pluginName}, possibly due to case mismatch. Trying to enumerate jQuery methods in lowercase. Add the correctly cased plugin name to the GlobalBehavior to avoid this performance hit.`);
+        for(var prop in jqueryElement){
+          if(prop.toLowerCase() === pluginName){
+            pluginName = prop;  
+          }
+        }
+      }
+      behavior.plugin = jqueryElement[pluginName](settings);  
     },
     unbind(behavior, element){
       if(typeof behavior.plugin.destroy === 'function'){


### PR DESCRIPTION
Enumerate all jQuery methods when a jQuery module is not found to fix case mismatch due to html attributes being returned in lower case. Emit a warning to include it in the global behavior

https://github.com/aurelia/framework/issues/47

Note: you need to add the aurelia-logging dependency in the application config.js