### PR TITLE
Repeat performance

### DIFF
--- a/src/repeat.js
+++ b/src/repeat.js
@@ -180,12 +180,12 @@ export class Repeat {
       removeDelta = 0,
       view, i, ii, j, jj, row, splice,
       addIndex, end, itemsLeftToAdd,
-      removed, model;
+      removed, model, totalAdded, totalRemoved;
 
     // TODO better way to handle Array.prototype.reverse()? Could this be a path for other use cases than reverse?
     if(splices.length === 2){
-      var totalAdded = splices[0].addedCount + splices[1].addedCount;
-      var totalRemoved = splices[0].removed.length + splices[1].removed.length;
+      totalAdded = splices[0].addedCount + splices[1].addedCount;
+      totalRemoved = splices[0].removed.length + splices[1].removed.length;
       if(totalAdded === totalRemoved){
         for(i = 0, ii = viewSlot.children.length; i < ii; ++i){
           view = this.viewSlot.children[i];


### PR DESCRIPTION
This should make the handleSplices-method a lot faster for all use cases I have tested, especially in cases where the array is swapped and where a lot of views are removed and added. 

Let me know if I have missed something or something does not make sense.

On line 186 is a code path to handle `Array.prototype.reverse()` it's probably the fastest way to handle it but not sure if that could be a code path for other use cases than reverse that would not work (not that I have found though).