### PR TITLE
fix(GlobalBehavior): throw AggregateError

### DIFF
--- a/src/global-behavior.js
+++ b/src/global-behavior.js
@@ -1,5 +1,6 @@
 import {inject} from 'aurelia-dependency-injection';
 import {customAttribute,dynamicOptions} from 'aurelia-templating';
+import {AggregateError} from 'aurelia-logging';
 import * as LogManager from 'aurelia-logging';
 
 @customAttribute('global-behavior')
@@ -20,7 +21,7 @@ export class GlobalBehavior {
     try{
       this.handler = handler.bind(this, this.element, this.aureliaCommand) || handler;
     }catch(error){
-      throw new Error('Conventional binding handler failed.', error);
+      throw AggregateError('Conventional binding handler failed.', error);
     }
   }
 


### PR DESCRIPTION
fixed incorrect passing of inner error to Error constructor

note: at some point the AggregateError function should be renamed to aggregateError, and all calls updated also.  AggregateError is a function that returns an aggregate error, not a class.  a common mistake associated with the incorrect name is the incorrect use of new when calling the function