### PR TITLE
fix(repeat): handle promises returned by view-slot

### DIFF
--- a/src/repeat.js
+++ b/src/repeat.js
@@ -193,7 +193,8 @@ export class Repeat {
   handleSplices(array, splices) {
     var viewLookup = new Map(),
       viewSlot = this.viewSlot,
-      spliceIndexLow, view, i, ii, j, jj, row, splice,
+      spliceIndexLow, viewOrPromise, view,
+      i, ii, j, jj, row, splice,
       addIndex, end, itemsLeftToAdd,
       removed, model, children, length;
 
@@ -213,9 +214,9 @@ export class Repeat {
           view.executionContext[this.local] = array[addIndex + j];
           --itemsLeftToAdd;
         } else {
-          view = viewSlot.removeAt(addIndex + splice.addedCount);
-          if(view){
-            viewLookup.set(removed[j], view);
+          viewOrPromise = viewSlot.removeAt(addIndex + splice.addedCount);
+          if(viewOrPromise){
+            viewLookup.set(removed[j], viewOrPromise);
           }
         }
       }
@@ -224,10 +225,17 @@ export class Repeat {
 
       for (; 0 < itemsLeftToAdd; ++addIndex) {
         model = array[addIndex];
-        view = viewLookup.get(model);
-        if(view){
+        viewOrPromise = viewLookup.get(model);
+        if(viewOrPromise instanceof Promise){
+          ((localAddIndex, localModel) => {
+            viewOrPromise.then(view => {
+              viewLookup.delete(localModel);
+              viewSlot.insert(localAddIndex, view);
+            });
+          })(addIndex, model);
+        }else if(viewOrPromise){
           viewLookup.delete(model);
-          viewSlot.insert(addIndex, view);
+          viewSlot.insert(addIndex, viewOrPromise);
         }else{
           row = this.createBaseExecutionContext(model);
           view = this.viewFactory.create(row);
@@ -248,7 +256,13 @@ export class Repeat {
       this.updateExecutionContext(children[spliceIndexLow].executionContext, spliceIndexLow, length);
     }
 
-    viewLookup.forEach(x => x.unbind());
+    viewLookup.forEach(x => {
+      if(x instanceof Promise){
+        x.then(y => y.unbind());
+      }else{
+        x.unbind();
+      }
+    });
   }
 
   handleMapChangeRecords(map, records) {


### PR DESCRIPTION
Templating was updated to support animations. Where removeAt() method may return a view or a promise. With this commit the repeater will be able to handle both return values. If its a promise the repeater will wait for it to resolve.

Closes #54

@EisenbergEffect / @jdanyow When reviewing this, in particular see if everything looks ok line 228 - 236. And let me know if any questions or changes should be made. 

This is confirmed by @zewa666 and @stoffeastrom to fix their issues.