### PR TITLE
fix(repeat): unbind children on property change

### DIFF
--- a/src/repeat.js
+++ b/src/repeat.js
@@ -93,11 +93,17 @@ export class Repeat {
 
   processItems() {
     var items = this.items,
-      viewSlot = this.viewSlot;
+      viewSlot = this.viewSlot,
+      views, i;
 
     if (this.disposeSubscription) {
       this.disposeSubscription();
+      views = viewSlot.children;
       viewSlot.removeAll();
+      i = views.length;
+      while(i--) {
+        views[i].unbind();
+      }
     }
 
     if(!items){


### PR DESCRIPTION
@martingust can you review this?  I'm a little out of my element here.  I was seeing a memory leak due to the repeat's child views never unbinding when the property the repeat was bound to was assigned a new array instance.

Here's an example:

```javascript
export class Foo {
  bars = [];  // bind a repeat to this.
  constructor() {
    setInterval(() => {
      this.bars = ['a', 'b', 'c'];  // this should cause the repeat's child views to unbind
    }, 0);
  }
}
```