### PR TITLE
fix(repeat): remove views when bindning new items

### DIFF
--- a/src/repeat.js
+++ b/src/repeat.js
@@ -42,7 +42,7 @@ export class Repeat {
 
     if(!items){
       if(this.oldItems){
-        this.viewSlot.removeAll();
+        this.removeAll();
       }
 
       return;
@@ -68,10 +68,14 @@ export class Repeat {
         this.disposeSubscription = observer.subscribe(splices => {
           this.handleSplices(items, splices);
         });
+
+        return;
       }
-    } else {
-      this.processItems();
+    } else if (this.oldItems) {
+      this.removeAll();
     }
+
+    this.processItems();
   }
 
   unbind(){
@@ -92,18 +96,11 @@ export class Repeat {
   }
 
   processItems() {
-    var items = this.items,
-      viewSlot = this.viewSlot,
-      views, i;
+    var items = this.items;
 
     if (this.disposeSubscription) {
       this.disposeSubscription();
-      views = viewSlot.children;
-      viewSlot.removeAll();
-      i = views.length;
-      while(i--) {
-        views[i].unbind();
-      }
+      this.removeAll();
     }
 
     if(!items){
@@ -333,6 +330,18 @@ export class Repeat {
       if (child.bindings[0].source[this.key] === key) {
         return i;
       }
+    }
+  }
+
+  removeAll(){
+    var viewSlot = this.viewSlot,
+      views, i;
+
+    views = viewSlot.children;
+    viewSlot.removeAll();
+    i = views.length;
+    while(i--) {
+      views[i].unbind();
     }
   }
 }

--- a/test/repeat.spec.js
+++ b/test/repeat.spec.js
@@ -1,0 +1,95 @@
+
+import {Repeat} from '../src/repeat';
+import {ObserverLocator} from 'aurelia-binding';
+import {BoundViewFactory} from 'aurelia-templating';
+
+class ViewSlotMock {
+  removeAll(){}
+  add(){}
+}
+
+class ViewMock {
+  unbind(){}
+}
+
+xdescribe('repeat', () => {
+  let repeat, viewSlot, viewFactory, view1, view2;
+
+  beforeEach(() => {
+    viewSlot = new ViewSlotMock();
+    viewFactory = new BoundViewFactory();
+    repeat = new Repeat(viewFactory, viewSlot, new ObserverLocator());
+    viewSlot.children = [];
+    spyOn(viewFactory, 'create').and.callFake(() => {});
+  });
+
+  describe('bind', () => {
+    it('should remove and unbind all old views if it has old items and provided with new items', () => {
+      view1 = new ViewMock();
+      view2 = new ViewMock();
+      viewSlot.children = [view1, view2];
+
+      repeat.items = ['1', '2'];
+      repeat.oldItems = ['a', 'b'];
+
+      spyOn(viewSlot, 'removeAll');
+      spyOn(view1, 'unbind');
+      spyOn(view2, 'unbind');
+
+      repeat.bind();
+
+      expect(viewSlot.removeAll).toHaveBeenCalled();
+      expect(view1.unbind).toHaveBeenCalled();
+      expect(view2.unbind).toHaveBeenCalled();
+    });
+
+    it('should remove and unbind all old views if it has old items and no new items', () => {
+      view1 = new ViewMock();
+      view2 = new ViewMock();
+      viewSlot.children = [view1, view2];
+
+      repeat.items = undefined;
+      repeat.oldItems = ['a', 'b'];
+
+      spyOn(viewSlot, 'removeAll');
+      spyOn(view1, 'unbind');
+      spyOn(view2, 'unbind');
+
+      repeat.bind();
+
+      expect(viewSlot.removeAll).toHaveBeenCalled();
+      expect(view1.unbind).toHaveBeenCalled();
+      expect(view2.unbind).toHaveBeenCalled();
+    });
+  });
+
+  describe('itemsChanged', () => {
+    it('should call disposeSubscription when has disposeSubscription', () => {
+      let disposeSubscription = () => {};
+      repeat.disposeSubscription = disposeSubscription;
+
+      spyOn(repeat, 'disposeSubscription');
+
+      repeat.itemsChanged();
+
+      expect(repeat.disposeSubscription).toHaveBeenCalled();
+    });
+
+    it('should remove all and unbind all view when has disposeSubscription', () => {
+      repeat.disposeSubscription = () => {};
+      view1 = new ViewMock();
+      view2 = new ViewMock();
+      viewSlot.children = [view1, view2];
+
+      spyOn(viewSlot, 'removeAll');
+      spyOn(view1, 'unbind');
+      spyOn(view2, 'unbind');
+
+      repeat.itemsChanged();
+
+      expect(viewSlot.removeAll).toHaveBeenCalled();
+      expect(view1.unbind).toHaveBeenCalled();
+      expect(view2.unbind).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Tests are temporary ignored until we get the infrastructure in place to test classes with bindable property initializers. See issue aurelia/binding#90

Fixes #69