### PR TITLE
fix(repeat): preserve lifecycle when re-using views

### DIFF
--- a/src/repeat.js
+++ b/src/repeat.js
@@ -214,22 +214,25 @@ export class Repeat {
       spliceIndexLow, viewOrPromise, view,
       i, ii, j, jj, row, splice,
       addIndex, end, itemsLeftToAdd,
-      removed, model, children, length;
+      removed, model, children, length, context, spliceIndex;
 
     for (i = 0, ii = splices.length; i < ii; ++i) {
       splice = splices[i];
-      addIndex = splice.index;
+      addIndex = spliceIndex = splice.index;
       itemsLeftToAdd = splice.addedCount;
       end = splice.index + splice.addedCount;
       removed = splice.removed;
       if(typeof spliceIndexLow === 'undefined' || spliceIndexLow === null || spliceIndexLow > splice.index){
-        spliceIndexLow = splice.index;
+        spliceIndexLow = spliceIndex;
       }
 
       for (j = 0, jj = removed.length; j < jj; ++j) {
         if (itemsLeftToAdd > 0) {
-          view = viewSlot.children[splice.index + j];
-          view.executionContext[this.local] = array[addIndex + j];
+          view = viewSlot.children[spliceIndex + j];
+          view.detached();
+          context = this.createFullExecutionContext(array[addIndex + j], spliceIndex + j, array.length);
+          view.bind(context);
+          view.attached();
           --itemsLeftToAdd;
         } else {
           viewOrPromise = viewSlot.removeAt(addIndex + splice.addedCount);

--- a/test/repeat.spec.js
+++ b/test/repeat.spec.js
@@ -6,9 +6,13 @@ import {BoundViewFactory} from 'aurelia-templating';
 class ViewSlotMock {
   removeAll(){}
   add(){}
+  insert(){}
 }
 
 class ViewMock {
+  bind(){}
+  attached(){}
+  detached(){}
   unbind(){}
 }
 
@@ -92,4 +96,62 @@ xdescribe('repeat', () => {
       expect(view2.unbind).toHaveBeenCalled();
     });
   });
+
+  describe('handleSplices', () => {
+    let view1, view2, view3, items, splices;
+
+    beforeEach(() => {
+      repeat.local = 'item';
+      view1 = new ViewMock();
+      view2 = new ViewMock();
+      view3 = new ViewMock();
+      view1.executionContext = {};
+      view2.executionContext = { item: 'qux' };
+      view3.executionContext = {};
+
+      viewSlot.children = [view1, view2, view3];
+    });
+
+    it('should preserve full view lifecycle when re-using views', () => {
+      items = ['Bar', 'Foo', 'Baz'];
+      splices = [{
+        addedCount: 2,
+        index: 1,
+        removed: ['qux']
+      }];
+
+      spyOn(view2, 'detached');
+      spyOn(view2, 'bind');
+      spyOn(view2, 'attached');
+
+      repeat.handleSplices(items, splices);
+
+      expect(view2.detached).toHaveBeenCalled();
+      expect(view2.bind).toHaveBeenCalled();
+      expect(view2.attached).toHaveBeenCalled();
+    });
+
+    it('should update execution context when re-using views', () => {
+      items = ['Bar', 'Foo', 'Baz'];
+      splices = [{
+        addedCount: 2,
+        index: 1,
+        removed: ['qux']
+      }];
+
+      spyOn(view2, 'bind');
+
+      repeat.handleSplices(items, splices);
+
+      let context = { item: 'Foo',
+        $parent: undefined,
+        $index: 1,
+        $first: false,
+        $last: false,
+        $middle: true,
+        $odd: true,
+        $even: false };
+      expect(view2.bind).toHaveBeenCalledWith(context);
+    });
+  })
 });


### PR DESCRIPTION
@EisenbergEffect Can you please review if this looks like expected behavior. When the view gets re-used the only thing that updates is the execution context's "item", one improvement might be to only update that and manually call `unbind` from inside the repeater, oppose the create a new full execution context. Let me know what you think.

@stoffeastrom I have tested this with some basic scenarios but I know you sortable plugin is a little more edge case, if you get any chance to test it out please let me know. I've created a gist with the compiled version of `repeat.js` https://gist.github.com/martingust/44ebf1f795628a229741