### PR TITLE
fix(show): use bind hook to handle undefined values

### DIFF
--- a/src/show.js
+++ b/src/show.js
@@ -32,4 +32,8 @@ export class Show {
       this.element.classList.add('aurelia-hide');
     }
   }
+
+  bind(executionContext) {
+    this.valueChanged(this.value);
+  }
 }


### PR DESCRIPTION
Fixes aurelia/templating#100

The valueChanged hook isn't called during initial binding when the model value is undefined because it matches the behavior property's intitial value (undefined).  Introducing the bind hook allows us to handle any initial value.