### PR TITLE
Much faster CSS fix up matcher

### DIFF
--- a/src/css-resource.js
+++ b/src/css-resource.js
@@ -4,10 +4,13 @@ import {Loader} from 'aurelia-loader';
 import {Container} from 'aurelia-dependency-injection';
 import {relativeToFile} from 'aurelia-path';
 
-let cssUrlMatcher = /url\(\s*[\'"]?(([^\\\\\'", \(\)]*(\\\\.)?)+)[\'"]?\s*\)/gi;
+let cssUrlMatcher = /url\((?!['"]data)([^)]+)\)/gi;
 
 function fixupCSSUrls(address, css) {
   return css.replace(cssUrlMatcher, (match, p1) => {
+    let quote = p1.charAt(0);
+    if(quote == '\'' || quote == '"')
+        p1 = p1.substr(1, p1.length - 2);
     return 'url(\'' + relativeToFile(p1, address) + '\')';
   });
 }


### PR DESCRIPTION
Better fixes #105 with virtually no impact on performance.

The solution here is use a combination of RegEx and Code to fix up CSS URLs. Massive reduction in RegEx complexity allows us to get to where we need to be faster :zap:; then just handle the edge cases for quoted URLs. These changes have virtually no impact in loading performance now. :+1: Roughly a **3x** speedup. Here is the performance difference:

#### Before :turtle:  
![screen457](https://cloud.githubusercontent.com/assets/478118/9708954/2e0a384e-54d8-11e5-912b-5ba8ac83c2b3.png)

#### After :zap: 
![screen458](https://cloud.githubusercontent.com/assets/478118/9708956/3366893c-54d8-11e5-99c1-0865b27fb1f8.png)
