### PR TITLE
feat(UpdateTriggerBindingBehavior): add behavior

### DIFF
--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -18,6 +18,7 @@ import {ThrottleBindingBehavior} from './throttle-binding-behavior';
 import {DebounceBindingBehavior} from './debounce-binding-behavior';
 import {SignalBindingBehavior} from './signal-binding-behavior';
 import {BindingSignaler} from './binding-signaler';
+import {UpdateTriggerBindingBehavior} from './update-trigger-binding-behavior';
 
 function configure(config) {
   if (FEATURE.shadowDOM) {
@@ -40,7 +41,8 @@ function configure(config) {
     './binding-mode-behaviors',
     './throttle-binding-behavior',
     './debounce-binding-behavior',
-    './signal-binding-behavior'
+    './signal-binding-behavior',
+    './update-trigger-binding-behavior'
   );
 
   let viewEngine = config.container.get(ViewEngine);
@@ -95,5 +97,6 @@ export {
   ThrottleBindingBehavior,
   DebounceBindingBehavior,
   SignalBindingBehavior,
-  BindingSignaler
+  BindingSignaler,
+  UpdateTriggerBindingBehavior
 };

--- a/src/update-trigger-binding-behavior.js
+++ b/src/update-trigger-binding-behavior.js
@@ -1,0 +1,34 @@
+import {bindingMode, EventManager} from 'aurelia-binding';
+
+const eventNamesRequired = `The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:'blur'">`;
+const notApplicableMessage = `The updateTrigger binding behavior can only be applied to two-way bindings on input/select elements.`;
+
+export class UpdateTriggerBindingBehavior {
+  static inject = [EventManager];
+
+  constructor(eventManager) {
+    this.eventManager = eventManager;
+  }
+
+  bind(binding, source, ...events) {
+    if (events.length === 0) {
+      throw new Error(eventNamesRequired);
+    }
+    if (binding.mode !== bindingMode.twoWay || !binding.targetProperty.handler) {
+      throw new Error(notApplicableMessage);
+    }
+
+    // stash the original element subscribe function.
+    binding.targetProperty.originalHandler = binding.targetProperty.handler;
+
+    // replace the element subscribe function with one that uses the correct events.
+    let handler = this.eventManager.createElementHandler(events);
+    binding.targetProperty.handler = handler;
+  }
+
+  unbind(binding, source) {
+    // restore the state of the binding.
+    binding.targetProperty.handler = binding.targetProperty.originalHandler;
+    binding.targetProperty.originalHandler = null;
+  }
+}

--- a/test/array-collection-strategy.spec.js
+++ b/test/array-collection-strategy.spec.js
@@ -27,7 +27,7 @@ describe('ArrayCollectionStrategy', () => {
     container.registerInstance(ObserverLocator, observerLocator);
     container.registerInstance(CollectionStrategyLocator, collectionStrategyLocator);
     let templatingEngine = new TemplatingEngine(container, new ModuleAnalyzer());
-    repeat = templatingEngine.createModelForUnitTest(Repeat);
+    repeat = templatingEngine.createViewModelForUnitTest(Repeat);
   });
 
   describe('handleChanges', () => {

--- a/test/number-strategy.spec.js
+++ b/test/number-strategy.spec.js
@@ -27,7 +27,7 @@ describe('NumberStrategy', () => {
     container.registerInstance(ObserverLocator, observerLocator);
     container.registerInstance(CollectionStrategyLocator, collectionStrategyLocator);
     let templatingEngine = new TemplatingEngine(container, new ModuleAnalyzer());
-    repeat = templatingEngine.createModelForUnitTest(Repeat);
+    repeat = templatingEngine.createViewModelForUnitTest(Repeat);
   });
 
   describe('processItems', () => {

--- a/test/repeat.spec.js
+++ b/test/repeat.spec.js
@@ -25,7 +25,7 @@ describe('repeat', () => {
     container.registerInstance(ObserverLocator, observerLocator);
     container.registerInstance(CollectionStrategyLocator, collectionStrategyLocator);
     let templatingEngine = new TemplatingEngine(container, new ModuleAnalyzer());
-    repeat = templatingEngine.createModelForUnitTest(Repeat);
+    repeat = templatingEngine.createViewModelForUnitTest(Repeat);
   });
 
   describe('bind', () => {

--- a/test/update-trigger-binding-behavior.spec.js
+++ b/test/update-trigger-binding-behavior.spec.js
@@ -1,0 +1,52 @@
+import {Container} from 'aurelia-dependency-injection';
+import {
+  bindingMode,
+  BindingEngine,
+  ListenerExpression,
+  ValueAttributeObserver,
+  createScopeForTest
+} from 'aurelia-binding';
+import {initialize as initializePAL} from 'aurelia-pal-browser';
+import {UpdateTriggerBindingBehavior} from '../src/update-trigger-binding-behavior';
+import {DOM} from 'aurelia-pal';
+
+describe('UpdateTriggerBindingBehavior', () => {
+  let bindingEngine, lookupFunctions;
+
+  beforeAll(() => {
+    let container = new Container();
+    initializePAL();
+    bindingEngine = container.get(BindingEngine);
+    let bindingBehaviors = {
+      updateTrigger: container.get(UpdateTriggerBindingBehavior)
+    };
+    lookupFunctions = { bindingBehaviors: name => bindingBehaviors[name] };
+  });
+
+  it('should apply update trigger events', () => {
+    let source = { foo: 'bar' };
+    let scope = createScopeForTest(source);
+    let target = document.createElement('input');
+    let bindingExpression = bindingEngine.createBindingExpression('value', `foo & updateTrigger:'blur':'paste'`, bindingMode.twoWay, lookupFunctions);
+    let binding = bindingExpression.createBinding(target);
+    let originalHandler = binding.targetProperty.handler;
+
+    binding.bind(scope);
+
+    target.value = 'baz';
+    target.dispatchEvent(DOM.createCustomEvent('change'));
+    expect(source.foo).toBe('bar');
+    target.dispatchEvent(DOM.createCustomEvent('blur'));
+    expect(source.foo).toBe('baz');
+
+    target.value = 'bang';
+    target.dispatchEvent(DOM.createCustomEvent('change'));
+    expect(source.foo).toBe('baz');
+    target.dispatchEvent(DOM.createCustomEvent('paste'));
+    expect(source.foo).toBe('bang');
+
+    binding.unbind();
+
+    expect(binding.targetProperty.handler).toBe(originalHandler);
+  });
+});


### PR DESCRIPTION
The UpdateTriggerBindingBehavior enables overriding the default input events ('change & input) used in two-way bindings to detect changes in the target element.

Fixes #137