### PR TITLE
Return null on undefined untrustedMarkup

### DIFF
--- a/src/sanitize-html.js
+++ b/src/sanitize-html.js
@@ -10,7 +10,7 @@ export class SanitizeHTMLValueConverter {
   }
 
   toView(untrustedMarkup) {
-    if (untrustedMarkup === null) {
+    if (untrustedMarkup === null || untrustedMarkup === undefined) {
       return null;
     }
 

--- a/test/sanitize-html.spec.js
+++ b/test/sanitize-html.spec.js
@@ -20,6 +20,7 @@ describe('SanitizeHtmlValueConverter', () => {
 
     expect(converter.toView('')).toBe('');
     expect(converter.toView(null)).toBe(null);
+    expect(converter.toView(undefined)).toBe(null);
     expect(converter.toView(a)).toBe('');
     expect(converter.toView(b)).toBe('<div></div>');
     expect(converter.toView(c)).toBe('foo  bar');


### PR DESCRIPTION
There are scenarios in which untrustedMarkup can be undefined (such as when splicing content into an array that is being repeated in a template) and exceptions are thrown. This change ensures a value of undefined returns null just like a value of null does.