### PR TITLE
tests won't run after `git clone ... ; npm install ; jspm install ; gulp test`

### DIFF
--- a/test/repeat-integration.spec.js
+++ b/test/repeat-integration.spec.js
@@ -489,7 +489,7 @@ function describeArrayTests(viewsRequireLifecycle) {
   });
 }
 
-describe('Repeat array (pure)', describeArrayTests);
+describe('Repeat array (pure)', describeArrayTests.bind(this, true));
 
 describe('Repeat array (not pure)', describeArrayTests.bind(this, false));
 


### PR DESCRIPTION
Without the added `.bind` jasmine thinks that the parameter `viewsRequireLifecycle` is the `done` argument, the current version pulled by the package.json dependency issues a warning for this as `describe` functions do not take a `done` parameter.