### PR TITLE
Silently ignore invalid collections

### DIFF
--- a/src/repeat.js
+++ b/src/repeat.js
@@ -120,6 +120,9 @@ export class Repeat {
 
     let items = this.items;
     this.strategy = this.strategyLocator.getStrategy(items);
+    if (!this.strategy) {
+      throw new Error(`Value for '${this.sourceExpression}' is non-repeatable`);
+    }
 
     if (!this.isOneTime && !this._observeInnerCollection()) {
       this._observeCollection();


### PR DESCRIPTION
First of all, I am not sure whether this PR is _the_ desired solution to my issue, but at least it would have made things less confusing to me.

I accidentally set a string rather than an array as replacement for an existing bound collection and got the following error: `cannot call method 'getCollectionObserver' of null`. Diving into the stack trace showed me the error was in the method `_observeCollection()`. I had to step trough this package to find out what actually caused this error and found out no repeat strategy could be selected (which makes sense). I am not sure what the desired behavior of Aurelia would be in such a case, but a general JavaScript error seems to be unwanted.

Please let me know if any additional information is required, I do not have the original code at hand right now.
