### PR TITLE
introduce AbstractRepeater

### DIFF
--- a/src/abstract-repeater.js
+++ b/src/abstract-repeater.js
@@ -82,4 +82,14 @@ export class AbstractRepeater {
   removeView(index: number, returnToCache?: boolean, skipAnimation?: boolean) {
     throw new Error('subclass must implement `removeView`');
   }
+
+  /**
+   * Forces a particular view to update it's bindings, called as part of
+   * an in-place processing of items for better performance
+   *
+   * @param {Object} view the target view for bindings updates
+   */
+  updateBindings(view: View) {
+    throw new Error('subclass must implement `updateBindings`');
+  }
 }

--- a/src/abstract-repeater.js
+++ b/src/abstract-repeater.js
@@ -1,0 +1,85 @@
+/**
+* An abstract base class for elements and attributes that repeat
+* views.
+*/
+export class AbstractRepeater {
+  constructor(options) {
+    Object.assign(this, {
+      local: 'items',
+      viewsRequireLifecycle: true
+    }, options);
+  }
+
+  /**
+   * Returns the number of views the repeater knows about.
+   *
+   * @return {Number}  the number of views.
+   */
+  viewCount() {
+    throw new Error('subclass must implement `viewCount`');
+  }
+
+  /**
+   * Returns all of the repeaters views as an array.
+   *
+   * @return {Array} The repeater's array of views;
+   */
+  views() {
+    throw new Error('subclass must implement `views`');
+  }
+
+  /**
+   * Returns a single view from the repeater at the provided index.
+   *
+   * @param {Number} index The index of the requested view.
+   * @return {View|ViewSlot} The requested view.
+   */
+  view(index) {
+    throw new Error('subclass must implement `view`');
+  }
+
+  /**
+   * Adds a view to the repeater, binding the view to the
+   * provided contexts.
+   *
+   * @param {Object} bindingContext The binding context to bind the new view to.
+   * @param {Object} overrideContext A secondary binding context that can override the primary context.
+   */
+  addView(bindingContext, overrideContext) {
+    throw new Error('subclass must implement `addView`');
+  }
+
+  /**
+   * Inserts a view to the repeater at a specific index, binding the view to the
+   * provided contexts.
+   *
+   * @param {Number} index The index at which to create the new view at.
+   * @param {Object} bindingContext The binding context to bind the new view to.
+   * @param {Object} overrideContext A secondary binding context that can override the primary context.
+   */
+  insertView(index, bindingContext, overrideContext) {
+    throw new Error('subclass must implement `insertView`');
+  }
+
+  /**
+   * Removes all views from the repeater.
+   * @param {Boolean} returnToCache Should the view be returned to the view cache?
+   * @param {Boolean} skipAnimation Should the removal animation be skipped?
+   * @return {Promise|null}
+   */
+  removeAllViews(returnToCache?: boolean, skipAnimation?: boolean) {
+    throw new Error('subclass must implement `removeAllViews`');
+  }
+
+  /**
+   * Removes a view from the repeater at a specific index.
+   *
+   * @param {Number} index The index of the view to be removed.
+   * @param {Boolean} returnToCache Should the view be returned to the view cache?
+   * @param {Boolean} skipAnimation Should the removal animation be skipped?
+   * @return {Promise|null}
+   */
+  removeView(index: number, returnToCache?: boolean, skipAnimation?: boolean) {
+    throw new Error('subclass must implement `removeView`');
+  }
+}

--- a/src/array-repeat-strategy.js
+++ b/src/array-repeat-strategy.js
@@ -1,4 +1,4 @@
-import {createFullOverrideContext, updateOverrideContexts, updateOneTimeBinding} from './repeat-utilities';
+import {createFullOverrideContext, updateOverrideContexts} from './repeat-utilities';
 import {mergeSplice} from 'aurelia-binding';
 
 /**
@@ -65,18 +65,7 @@ export class ArrayRepeatStrategy {
       view.bindingContext[local] = items[i];
       view.overrideContext.$middle = middle;
       view.overrideContext.$last = last;
-      let j = view.bindings.length;
-      while (j--) {
-        updateOneTimeBinding(view.bindings[j]);
-      }
-      j = view.controllers.length;
-      while (j--) {
-        let k = view.controllers[j].boundProperties.length;
-        while (k--) {
-          let binding = view.controllers[j].boundProperties[k].binding;
-          updateOneTimeBinding(binding);
-        }
-      }
+      repeat.updateBindings(view);
     }
     // add new views
     for (let i = viewsLength; i < itemsLength; i++) {

--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -20,6 +20,7 @@ import {DebounceBindingBehavior} from './debounce-binding-behavior';
 import {SignalBindingBehavior} from './signal-binding-behavior';
 import {BindingSignaler} from './binding-signaler';
 import {UpdateTriggerBindingBehavior} from './update-trigger-binding-behavior';
+import {AbstractRepeater} from './abstract-repeater';
 
 function configure(config) {
   if (FEATURE.shadowDOM) {
@@ -101,5 +102,6 @@ export {
   DebounceBindingBehavior,
   SignalBindingBehavior,
   BindingSignaler,
-  UpdateTriggerBindingBehavior
+  UpdateTriggerBindingBehavior,
+  AbstractRepeater
 };

--- a/src/null-repeat-strategy.js
+++ b/src/null-repeat-strategy.js
@@ -3,7 +3,7 @@
 */
 export class NullRepeatStrategy {
   instanceChanged(repeat, items) {
-    repeat.viewSlot.removeAll(true);
+    repeat.removeAllViews(true);
   }
 
   getCollectionObserver(observerLocator, items) {

--- a/src/number-repeat-strategy.js
+++ b/src/number-repeat-strategy.js
@@ -16,7 +16,7 @@ export class NumberRepeatStrategy {
   * @param value The Number of how many time to iterate.
   */
   instanceChanged(repeat, value) {
-    let removePromise = repeat.viewSlot.removeAll(true);
+    let removePromise = repeat.removeAllViews(true);
     if (removePromise instanceof Promise) {
       removePromise.then(() => this._standardProcessItems(repeat, value));
       return;
@@ -25,9 +25,7 @@ export class NumberRepeatStrategy {
   }
 
   _standardProcessItems(repeat, value) {
-    let viewFactory = repeat.viewFactory;
-    let viewSlot = repeat.viewSlot;
-    let childrenLength = viewSlot.children.length;
+    let childrenLength = repeat.viewCount();
     let i;
     let ii;
     let overrideContext;
@@ -43,7 +41,7 @@ export class NumberRepeatStrategy {
       }
 
       for (i = 0, ii = viewsToRemove; i < ii; ++i) {
-        viewSlot.removeAt(childrenLength - (i + 1), true);
+        repeat.removeView(childrenLength - (i + 1), true);
       }
 
       return;
@@ -51,11 +49,9 @@ export class NumberRepeatStrategy {
 
     for (i = childrenLength, ii = value; i < ii; ++i) {
       overrideContext = createFullOverrideContext(repeat, i, i, ii);
-      view = viewFactory.create();
-      view.bind(overrideContext.bindingContext, overrideContext);
-      viewSlot.add(view);
+      repeat.addView(overrideContext.bindingContext, overrideContext);
     }
 
-    updateOverrideContexts(repeat.viewSlot.children, 0);
+    updateOverrideContexts(repeat.views(), 0);
   }
 }

--- a/src/repeat.js
+++ b/src/repeat.js
@@ -14,7 +14,8 @@ import {RepeatStrategyLocator} from './repeat-strategy-locator';
 import {
   getItemsSourceExpression,
   unwrapExpression,
-  isOneTime
+  isOneTime,
+  updateOneTimeBinding
 } from './repeat-utilities';
 import {viewsRequireLifecycle} from './analyze-view-factory';
 import {AbstractRepeater} from './abstract-repeater';
@@ -198,7 +199,7 @@ export class Repeat extends AbstractRepeater {
     }
   }
 
-  // implementation of AbstractRepeater
+  // @override AbstractRepeater
   viewCount() { return this.viewSlot.children.length; }
   views() { return this.viewSlot.children; }
   view(index) { return this.viewSlot.children[index]; }
@@ -221,5 +222,20 @@ export class Repeat extends AbstractRepeater {
 
   removeView(index, returnToCache, skipAnimation) {
     return this.viewSlot.removeAt(index, returnToCache, skipAnimation);
+  }
+
+  updateBindings(view: View) {
+    let j = view.bindings.length;
+    while (j--) {
+      updateOneTimeBinding(view.bindings[j]);
+    }
+    j = view.controllers.length;
+    while (j--) {
+      let k = view.controllers[j].boundProperties.length;
+      while (k--) {
+        let binding = view.controllers[j].boundProperties[k].binding;
+        updateOneTimeBinding(binding);
+      }
+    }
   }
 }


### PR DESCRIPTION
The `AbstractRepeater` is a base class for all attributes or elements that repeat views/templates over a collection. It's meant primarily to provide an abstraction for anyone who wants to create something like the baked in `repeat` attribute. The flexibility of the interface allows you to implement repeat-esque elements over more complicated components (particularly multi-dimensional datasets like a grid, where each "item"/"row" might actually have multiple views).

I think this is a good place to start, there are a number of nitpicks I can point out off the top of my head:
  * `addView` is more like `createAndAddView`
  * `insertView` => `insertViewAt`, as well as the above comment
  * `removeView` => `removeViewAt`
  the list could go on

I'm not sure what kind of conventions y'all prefer, and am not tied whatsoever to the existing naming.