### PR TITLE
fix(if): queue up changes when animating

### DIFF
--- a/src/array-repeat-strategy.js
+++ b/src/array-repeat-strategy.js
@@ -106,8 +106,8 @@ export class ArrayRepeatStrategy {
 
       let runQueuedSplices = () => {
         if (!queuedSplices.length) {
-          delete repeat.__queuedSplices;
-          delete repeat.__array;
+          repeat.__queuedSplices = undefined;
+          repeat.__array = undefined;
           return;
         }
 

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -104,6 +104,50 @@ describe('if', () => {
 
     expect(view.bind).toHaveBeenCalled();
   });
+  
+  describe('during animation', () => {
+    let delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    let removeWithAnimation = animationDuration => {
+      return function(view) {
+        return delay(animationDuration).then(() => {            
+          this.children = [];
+        });
+      };
+    };
+      
+    let addWithAnimation = animationDuration => {
+      return function(view) {
+        return delay(animationDuration).then(() => {          
+          this.children.push(view);
+        });
+      };
+    };
+
+    beforeEach(() => {   
+      spyOn(viewSlot, 'remove').and.callFake(removeWithAnimation(600));
+      spyOn(viewSlot, 'add').and.callFake(addWithAnimation(0));
+    });
+
+    it('should correctly handle value changes during remove animation', done => {  
+      sut.showing = false;
+      sut.view = new ViewMock();  
+      sut.view.isBound = true;        
+      sut.viewSlot.children = [];
+      sut.valueChanged(true);        
+   
+      delay(200).then(() => {          
+        sut.valueChanged(false);
+        return delay(400);
+      }).then(() => {
+        sut.valueChanged(true);
+        return delay(600);          
+      }).then(() => {  
+        expect(viewSlot.children.length).toEqual(1);
+      })
+      .then(() => done())
+    })
+  });
 });
 
 class ViewSlotMock {


### PR DESCRIPTION
Changes are now being queued when animating, same approach as `repeat`.

@jdanyow @EisenbergEffect If this looks to you guys, this is ready to be merged.