### PR TITLE
fix(exports): export RepeatStrategyLocator

### DIFF
--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -103,5 +103,6 @@ export {
   SignalBindingBehavior,
   BindingSignaler,
   UpdateTriggerBindingBehavior,
-  AbstractRepeater
+  AbstractRepeater,
+  RepeatStrategyLocator
 };


### PR DESCRIPTION
AbstractRepeater isn't very useful if you don't have access to the repeat strategies! I stupidly left this out of my AbstractRepeater PR it seems..