### PR TITLE
refactor(index): export repeat strategies

### DIFF
--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -22,6 +22,11 @@ import {UpdateTriggerBindingBehavior} from './update-trigger-binding-behavior';
 import {AbstractRepeater} from './abstract-repeater';
 import {RepeatStrategyLocator} from './repeat-strategy-locator';
 import {configure as configureHtmlResourcePlugin} from './html-resource-plugin';
+import {NullRepeatStrategy} from './null-repeat-strategy';
+import {ArrayRepeatStrategy} from './array-repeat-strategy';
+import {MapRepeatStrategy} from './map-repeat-strategy';
+import {SetRepeatStrategy} from './set-repeat-strategy';
+import {NumberRepeatStrategy} from './number-repeat-strategy';
 
 function configure(config) {
   if (FEATURE.shadowDOM) {
@@ -82,5 +87,10 @@ export {
   BindingSignaler,
   UpdateTriggerBindingBehavior,
   AbstractRepeater,
-  RepeatStrategyLocator
+  RepeatStrategyLocator,
+  NullRepeatStrategy,
+  ArrayRepeatStrategy,
+  MapRepeatStrategy,
+  SetRepeatStrategy,
+  NumberRepeatStrategy
 };


### PR DESCRIPTION
As I'm not sure if [this syntax](https://github.com/aurelia-ui-toolkits/aurelia-kendoui-bridge/commit/2ffd03520231a63f964df9564e556fd9867989e8#diff-1fdf421c05c1140f6d71444ea2b27638R3) is supported by all loaders I'd rather follow the standard and export the things I need from index.js