### PR TITLE
feat(templating): support popular transpilers

### DIFF
--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -68,7 +68,7 @@ function configure(config) {
       return { [address]: _createCSSResource(address) };
     }
   };
-  ['.css', '.less', '.sass', '.scss'].forEach(ext => viewEngine.addResourcePlugin(ext, styleResourcePlugin));
+  ['.css', '.less', '.sass', '.scss', '.styl'].forEach(ext => viewEngine.addResourcePlugin(ext, styleResourcePlugin));
 }
 
 export {

--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -63,11 +63,12 @@ function configure(config) {
   configureHtmlResourcePlugin(config);
 
   let viewEngine = config.container.get(ViewEngine);
-  viewEngine.addResourcePlugin('.css', {
-    'fetch': function(address) {
+  let styleResourcePlugin = {
+    fetch(address) {
       return { [address]: _createCSSResource(address) };
     }
-  });
+  };
+  ['.css', '.less', '.sass', '.scss'].forEach(ext => viewEngine.addResourcePlugin(ext, styleResourcePlugin));
 }
 
 export {


### PR DESCRIPTION
LESS and SASS extensions can now be loaded as `<style>` by `<require from=style.less>` in views.
Of course, content should previously have been properly compiled to CSS.

Fixed #277 