### PR TITLE
feat(templating): else custom attribute

### DIFF
--- a/src/if.js
+++ b/src/if.js
@@ -87,7 +87,7 @@ class IfCore {
 @inject(BoundViewFactory, ViewSlot)
 export class If extends IfCore {
   @bindable({ primaryProperty: true }) condition: any;
-  @bindable swap: "before"|"with"|"after";
+  @bindable swapOrder: "before"|"with"|"after";
 
   /**
   * Binds the if to the binding context and override context
@@ -132,7 +132,7 @@ export class If extends IfCore {
   }
 
   _swap(remove, add) {
-    switch (this.swap) {
+    switch (this.swapOrder) {
       case "before":
         return Promise.resolve(add._show()).then(() => remove._hide());
       case "with":

--- a/src/if.js
+++ b/src/if.js
@@ -1,82 +1,53 @@
-import {BoundViewFactory, ViewSlot, customAttribute, templateController} from 'aurelia-templating';
+import {BoundViewFactory, ViewSlot, bindable, customAttribute, templateController} from 'aurelia-templating';
 import {inject} from 'aurelia-dependency-injection';
+import {DOM} from 'aurelia-pal';
 
-/**
-* Binding to conditionally include or not include template logic depending on returned result
-* - value should be Boolean or will be treated as such (truthy / falsey)
-*/
-@customAttribute('if')
-@templateController
-@inject(BoundViewFactory, ViewSlot)
-export class If {
-  /**
-  * Creates an instance of If.
-  * @param {BoundViewFactory} viewFactory The factory generating the view
-  * @param {ViewSlot} viewSlot The slot the view is injected in to
-  */
+class IfCore {
   constructor(viewFactory, viewSlot) {
     this.viewFactory = viewFactory;
     this.viewSlot = viewSlot;
-    this.showing = false;
     this.view = null;
     this.bindingContext = null;
     this.overrideContext = null;
+    // If the child view is animated, `value` might not reflect the internal 
+    // state anymore, so we use `showing` for that. 
+    // Eventually, `showing` and `value` should be consistent.
+    this.showing = false;
   }
 
-  /**
-  * Binds the if to the binding context and override context
-  * @param bindingContext The binding context
-  * @param overrideContext An override context for binding.
-  */
   bind(bindingContext, overrideContext) {
     // Store parent bindingContext, so we can pass it down
     this.bindingContext = bindingContext;
     this.overrideContext = overrideContext;
-    this.valueChanged(this.value);
   }
 
-  /**
-  * Invoked everytime value property changes.
-  * @param newValue The new value
-  */
-  valueChanged(newValue) {
-    if (this.__queuedChanges) {
-      this.__queuedChanges.push(newValue);
+  unbind() {
+    if (this.view === null) {
       return;
     }
 
-    let maybePromise = this._runValueChanged(newValue);
-    if (maybePromise instanceof Promise) {
-      let queuedChanges = this.__queuedChanges = [];
+    this.view.unbind();
 
-      let runQueuedChanges = () => {
-        if (!queuedChanges.length) {
-          this.__queuedChanges = undefined;
-          return;
-        }
-
-        let nextPromise = this._runValueChanged(queuedChanges.shift()) || Promise.resolve();
-        nextPromise.then(runQueuedChanges);
-      };
-
-      maybePromise.then(runQueuedChanges);
+    // It seems to me that this code is subject to race conditions when animating.
+    // For example a view could be returned to the cache and reused while it's still
+    // attached to the DOM and animated.
+    if (!this.viewFactory.isCaching) {
+      return;
     }
+    
+    if (this.showing) {
+      this.showing = false;
+      this.viewSlot.remove(this.view, /*returnToCache:*/true, /*skipAnimation:*/true);
+    }
+    else {
+      this.view.returnToCache();
+    }
+    this.view = null;
   }
 
-  _runValueChanged(newValue) {
-    if (!newValue) {
-      let viewOrPromise;
-      if (this.view !== null && this.showing) {
-        viewOrPromise = this.viewSlot.remove(this.view);
-        if (viewOrPromise instanceof Promise) {
-          viewOrPromise.then(() => this.view.unbind());
-        } else {
-          this.view.unbind();
-        }
-      }
-
-      this.showing = false;
-      return viewOrPromise;
+  _show() {
+    if (this.showing) {
+      return;
     }
 
     if (this.view === null) {
@@ -87,33 +58,115 @@ export class If {
       this.view.bind(this.bindingContext, this.overrideContext);
     }
 
+    this.showing = true;
+    return this.viewSlot.add(this.view); // Promise or void
+  }
+
+  _hide() {
     if (!this.showing) {
-      this.showing = true;
-      return this.viewSlot.add(this.view);
+      return;
     }
 
-    return undefined;
+    this.showing = false;
+    let removed = this.viewSlot.remove(this.view); // Promise or View
+    if (removed instanceof Promise) {
+      return removed.then(() => this.view.unbind());
+    } 
+    else {
+      this.view.unbind();
+    }                
+  }
+}
+
+/**
+* Binding to conditionally include or not include template logic depending on returned result
+* - value should be Boolean or will be treated as such (truthy / falsey)
+*/
+@customAttribute('if')
+@templateController
+@inject(BoundViewFactory, ViewSlot)
+export class If extends IfCore {
+  @bindable({ primaryProperty: true }) condition: any;
+  @bindable swap: "before"|"with"|"after";
+
+  /**
+  * Binds the if to the binding context and override context
+  * @param bindingContext The binding context
+  * @param overrideContext An override context for binding.
+  */
+  bind(bindingContext, overrideContext) {
+    super.bind(bindingContext, overrideContext);
+    this.conditionChanged(this.condition);
   }
 
   /**
-  * Unbinds the if
+  * Invoked everytime value property changes.
+  * @param newValue The new value
   */
-  unbind() {
-    if (this.view === null) {
-      return;
+  conditionChanged(newValue) {
+    this._update(newValue);
+  }
+  
+  _update(show) {
+    if (this.animating) {
+      return;      
     }
 
-    this.view.unbind();
-
-    if (!this.viewFactory.isCaching) {
-      return;
+    let promise;
+    if (this.else) {
+      promise = show ? this._swap(this.else, this) : this._swap(this, this.else);
+    }
+    else {
+      promise = show ? this._show() : this._hide();
     }
 
-    if (this.showing) {
-      this.showing = false;
-      this.viewSlot.remove(this.view, true, true);
+    if (promise) {
+      this.animating = true;
+      promise.then(() => {
+        this.animating = false;
+        if (this.condition !== this.showing) {
+          this._update(this.condition);
+        }
+      });
     }
-    this.view.returnToCache();
-    this.view = null;
+  }
+
+  _swap(remove, add) {
+    switch (this.swap) {
+      case "before":
+        return Promise.resolve(add._show()).then(() => remove._hide());
+      case "with":
+        return Promise.all([ remove._hide(), add._show() ]);
+      default:  // "after", default and unknown values
+        let promise = remove._hide();
+        return promise ? promise.then(() => add._show()) : add._show();
+    }
+  }
+}
+
+@customAttribute('else')
+@templateController
+@inject(BoundViewFactory, ViewSlot)
+export class Else extends IfCore {  
+  constructor(viewFactory, viewSlot) {
+    super(viewFactory, viewSlot);
+    this._registerInIf();
+  }
+
+  _registerInIf() {
+    // We support the pattern <div if.bind="x"></div><div else></div>.
+    // Obvisouly between the two, we must accepts text (spaces) and comments.
+    // The `if` node is expected to be a comment anchor, because of `@templateController`.
+    // To simplify the code we basically walk up to the first Aurelia predecessor,
+    // so having static tags in between (no binding) would work but is not intended to be supported.
+    let previous = this.viewSlot.anchor.previousSibling;
+    while (previous && !previous.au) {
+      previous = previous.previousSibling;
+    }
+    if (!previous || !previous.au.if) {
+      throw new Error("Can't find matching If for Else custom attribute.");
+    }
+    let ifVm = previous.au.if.viewModel;
+    ifVm.else = this;
   }
 }


### PR DESCRIPTION
This PR introduces an `else` custom attribute that can be used directly following a `if` binding:
```html
<div if.bind="whatever">Whatever is truthy!</div>
<div else>No luck</div>
```

It also introduces an option to `if`.
- `condition` is the default option, as above.
- `swap: "after"|"with"|"before"` coordinates the animations (if any) between the `if` and the `else` templates.
```html
<div if="condition.bind: whatever; swap: with">Yes</div>
<div else class="au-animate">No</div>
```

The advantages of this are:
- Simpler, more intuitive to use. Especially when `condition` is a complex expression.
- The pair only subscribes for changes once.
- Coordinated animations.

⚠️ **Don't merge this before aurelia/templating#537 and remember to bump the minimum dependency!!** Otherwise using `if` results in infinite recursion.

Tests cases will come later but the code is ready for review.

Fixes #171 

CC @EisenbergEffect @jdanyow for review
CC @MeirionHughes because you asked me to

![2017-03-19_22-19-44](https://cloud.githubusercontent.com/assets/3832820/24085036/edc088fc-0cf4-11e7-8c91-8e8edd83e2b5.gif)