### PR TITLE
proposed fix for issue 287

### DIFF
--- a/src/map-repeat-strategy.js
+++ b/src/map-repeat-strategy.js
@@ -47,6 +47,7 @@ export class MapRepeatStrategy {
     let ii;
     let overrideContext;
     let removeIndex;
+    let addIndex;
     let record;
     let rmPromises = [];
     let viewOrPromise;
@@ -65,7 +66,8 @@ export class MapRepeatStrategy {
         repeat.insertView(removeIndex, overrideContext.bindingContext, overrideContext);
         break;
       case 'add':
-        overrideContext = createFullOverrideContext(repeat, map.get(key), map.size - 1, map.size, key);
+        addIndex = repeat.viewCount() <= map.size - 1 ? repeat.viewCount() : map.size - 1;
+        overrideContext = createFullOverrideContext(repeat, map.get(key), addIndex, map.size, key);
         repeat.insertView(map.size - 1, overrideContext.bindingContext, overrideContext);
         break;
       case 'delete':

--- a/test/map-repeat-strategy.spec.js
+++ b/test/map-repeat-strategy.spec.js
@@ -1,6 +1,5 @@
 import './setup';
 import {ObserverLocator, createOverrideContext} from 'aurelia-binding';
-import {BoundViewFactory, ViewSlot, ViewFactory, ModuleAnalyzer, TargetInstruction, ViewResources} from 'aurelia-templating';
 import {StageComponent} from 'aurelia-testing';
 import {Container} from 'aurelia-dependency-injection';
 import {Repeat} from '../src/repeat';
@@ -85,7 +84,7 @@ describe('MapRepeatStrategy', () => {
       expect(viewSlotMock.children.length).toBe(0);
     });
   
-    it('should correctly handle adding items after clear (issue 184)', () => {
+    it('should correctly handle adding items after clear (issue 287)', () => {
       viewSlot.children = [view1, view2, view3];
       repeat = new Repeat(new ViewFactoryMock(), instructionMock, viewSlot, viewResourcesMock, new ObserverLocator());
       let bindingContext = {};

--- a/test/map-repeat-strategy.spec.js
+++ b/test/map-repeat-strategy.spec.js
@@ -1,0 +1,116 @@
+import './setup';
+import {ObserverLocator, createOverrideContext} from 'aurelia-binding';
+import {BoundViewFactory, ViewSlot, ViewFactory, ModuleAnalyzer, TargetInstruction, ViewResources} from 'aurelia-templating';
+import {StageComponent} from 'aurelia-testing';
+import {Container} from 'aurelia-dependency-injection';
+import {Repeat} from '../src/repeat';
+import {MapRepeatStrategy} from '../src/map-repeat-strategy';
+import {ViewSlotMock, BoundViewFactoryMock, ViewMock, ViewFactoryMock, instructionMock, viewResourcesMock} from './mocks';
+import {bootstrap} from 'aurelia-bootstrapper';
+
+describe('MapRepeatStrategy', () => {
+  let repeat, strategy, viewSlot, viewFactory, observerLocator, repeatStrategyLocator, repeatStrategyMock, component;
+
+  beforeEach(done => {
+    let aurelia;
+    let container = new Container();
+    viewSlot = new ViewSlotMock();
+    viewFactory = new BoundViewFactoryMock();
+    strategy = new MapRepeatStrategy();
+
+    component = StageComponent.withResources().inView('<div repeat.for="[key, value] of items"></div>').boundTo({ items: new Map() });
+
+    component.create(bootstrap).then(() => {
+      repeat = component.viewModel;
+      repeat.viewSlot = viewSlot;
+      repeat.instruction = instructionMock;
+      repeat.viewFactory = viewFactory;
+      repeat.viewsRequireLifecycle = true;
+      done();
+    });
+  });
+
+  describe('instanceMutated', () => {
+    let view1, view2, view3, items, records, viewFactorySpy;
+
+    beforeEach(() => {
+      strategy = new MapRepeatStrategy();
+      viewSlot.children = [];
+      view1 = new ViewMock();
+      view2 = new ViewMock();
+      view3 = new ViewMock();
+      view1.bindingContext = { item: ['foo', 'bar'] };
+      view1.overrideContext = {};
+      view2.bindingContext = { item: ['qux', 'qax'] };
+      view2.overrideContext = {};
+      view3.bindingContext = { item: ['john', 'doe'] };
+      view3.overrideContext = {};
+      viewSlot.children = [view1, view2, view3];
+      viewFactorySpy = spyOn(viewFactory, 'create').and.callFake(() => {});
+    });
+  
+    it('should correctly handle adding item (i.e Map.prototype.set())', () => {
+      repeat = new Repeat(new ViewFactoryMock(), instructionMock, viewSlot, viewResourcesMock, new ObserverLocator());
+      let bindingContext = {};
+      repeat.scope = { bindingContext, overrideContext: createOverrideContext(bindingContext) };
+      records = [
+        {"type": "add", "object": {}, "key": 'norf'}
+      ]
+      items = new Map([['foo', 'bar'], ['qux', 'qax'], ['john', 'doe'], ['norf', 'narf']]);
+      spyOn(viewSlot, 'removeAt').and.callFake(() => { return new ViewMock();});
+      strategy.instanceMutated(repeat, items, records);
+    
+      expect(viewSlot.children.length).toBe(4);
+      expect(viewSlot.children[3].bindingContext.key).toBe('norf');
+      expect(viewSlot.children[3].overrideContext.$index).toBe(3);
+      expect(viewSlot.children[3].overrideContext.$first).toBe(false);
+      expect(viewSlot.children[3].overrideContext.$last).toBe(true);
+    });
+  
+    it('should correctly handle clear items (i.e Map.prototype.clear())', () => {
+      let view4 = new ViewMock();
+      view4.bindingContext = { item: ['norf', 'narf'] };
+      view4.overrideContext = {};
+      let viewSlotMock = new ViewSlotMock();
+      viewSlotMock.children = [view1, view2, view3, view4];
+      repeat = new Repeat(new ViewFactoryMock(), instructionMock, viewSlotMock, viewResourcesMock, new ObserverLocator());
+      let bindingContext = {};
+      repeat.scope = { bindingContext, overrideContext: createOverrideContext(bindingContext) };
+      records = [
+        {"type": "clear", "object": {}}
+      ]
+      items = new Map();
+      strategy.instanceMutated(repeat, items, records);
+    
+      expect(viewSlotMock.children.length).toBe(0);
+    });
+  
+    it('should correctly handle adding items after clear (issue 184)', () => {
+      viewSlot.children = [view1, view2, view3];
+      repeat = new Repeat(new ViewFactoryMock(), instructionMock, viewSlot, viewResourcesMock, new ObserverLocator());
+      let bindingContext = {};
+      repeat.scope = { bindingContext, overrideContext: createOverrideContext(bindingContext) };
+      records = [
+        {"type": "clear", "object": {}},
+        {"type": "add", "object": {}, "key": 'foo'},
+        {"type": "add", "object": {}, "key": 'qux'},
+        {"type": "add", "object": {}, "key": 'john'},
+        {"type": "add", "object": {}, "key": 'norf'}
+      ]
+      items = new Map([['foo', 'bar'], ['qux', 'qax'], ['john', 'doe'], ['norf', 'narf']]);
+      strategy.instanceMutated(repeat, items, records);
+
+      expect(viewSlot.children.length).toBe(4);
+      expect(viewSlot.children[0].bindingContext.key).toBe('foo');
+      expect(viewSlot.children[0].overrideContext.$index).toBe(0);
+      expect(viewSlot.children[0].overrideContext.$first).toBe(true);
+      expect(viewSlot.children[0].overrideContext.$last).toBe(false);
+      expect(viewSlot.children[3].bindingContext.key).toBe('norf');
+      expect(viewSlot.children[3].overrideContext.$index).toBe(3);
+      expect(viewSlot.children[3].overrideContext.$first).toBe(false);
+      expect(viewSlot.children[3].overrideContext.$last).toBe(true);
+    });
+
+  });
+
+});

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -2,7 +2,9 @@ export class ViewSlotMock {
   constructor() {
     this.children = [];
   }
-  removeAll(){}
+  removeAll(){
+    this.children.splice(0, this.children.length);
+  }
   add(view){
     this.children.push(view);
   }


### PR DESCRIPTION
Fix propsed for wrong map indexes after map content changed. See #287 .
I also added some tests for map-repeat-strategy. 

The 'should correctly handle adding items after clear (issue 287)' test is somehow always ok. Even without the fix. I think this has something to do with wrong override context being bound to the viewSlot.children. But this is just an error in the test which I dont understand. When I step through map-repeat-strategy.js and updateOverrideContext() in repeat-utilities.js the index is now being set right! 

@jdanyow Hope that helps :) 