### PR TITLE
refactor(Focus): Use handleEvent instead of arrow functions

### DIFF
--- a/src/focus.js
+++ b/src/focus.js
@@ -69,19 +69,9 @@ export class Focus {
   }
 
   handleEvent(e) {
-    switch (e.type) {
-    case 'focus': this.handleFocus(e); break;
-    case 'blur': this.handleBlur(e); break;
-    default: break;
-    }
-  }
-
-  handleFocus(e) {
-    this.value = true;
-  }
-
-  handleBlur(e) {
-    if (DOM.activeElement !== this.element) {
+    if (e.type === 'focus') {
+      this.value = true;
+    } else if (DOM.activeElement !== this.element) {
       this.value = false;
     }
   }

--- a/src/focus.js
+++ b/src/focus.js
@@ -20,15 +20,6 @@ export class Focus {
     this.taskQueue = taskQueue;
     this.isAttached = false;
     this.needsApply = false;
-
-    this.focusListener = e => {
-      this.value = true;
-    };
-    this.blurListener = e => {
-      if (DOM.activeElement !== this.element) {
-        this.value = false;
-      }
-    };
   }
 
   /**
@@ -64,8 +55,8 @@ export class Focus {
       this.needsApply = false;
       this._apply();
     }
-    this.element.addEventListener('focus', this.focusListener);
-    this.element.addEventListener('blur', this.blurListener);
+    this.element.addEventListener('focus', this);
+    this.element.addEventListener('blur', this);
   }
 
   /**
@@ -73,7 +64,25 @@ export class Focus {
   */
   detached() {
     this.isAttached = false;
-    this.element.removeEventListener('focus', this.focusListener);
-    this.element.removeEventListener('blur', this.blurListener);
+    this.element.removeEventListener('focus', this);
+    this.element.removeEventListener('blur', this);
+  }
+
+  handleEvent(e) {
+    switch (e.type) {
+    case 'focus': this.handleFocus(e); break;
+    case 'blur': this.handleBlur(e); break;
+    default: break;
+    }
+  }
+
+  handleFocus(e) {
+    this.value = true;
+  }
+
+  handleBlur(e) {
+    if (DOM.activeElement !== this.element) {
+      this.value = false;
+    }
   }
 }


### PR DESCRIPTION
This PR replaces 2 arrow functions: `focusListener` & `blurListener` by `handleEvent`, leveraging event target interface for lower memory consumption.