### PR TITLE
fix(array-repeat): olditem bindingcontext not available

### DIFF
--- a/src/array-repeat-strategy.js
+++ b/src/array-repeat-strategy.js
@@ -50,7 +50,7 @@ export class ArrayRepeatStrategy {
 
       for (let index = 0; index < viewsLength; index++) {
         const view = childrenSnapshot[index];
-        const oldItem = view.bindingContext[itemNameInBindingContext];
+        const oldItem = view.bindingContext ? view.bindingContext[itemNameInBindingContext] : null;
 
         if (indexOf(items, oldItem, matcher) === -1) {
           // remove the item if no longer in the new instance of items


### PR DESCRIPTION
fix an issue where due to delayed rendering the bindingContext of the oldItem might not be available

fixes issue https://github.com/aurelia/animator-velocity/issues/21