### PR TITLE
test: fix createAssertionQueue behaviour in repeat-integration spec.

### DIFF
--- a/test/repeat-integration.spec.js
+++ b/test/repeat-integration.spec.js
@@ -116,11 +116,11 @@ function createAssertionQueue() {
   let next;
   next = () => {
     if (queue.length) {
-      let func = queue.pop();
       setTimeout(() => {
+        let func = queue.shift();
         func();
         next();
-      })
+      });
     }
   };
 
@@ -160,7 +160,7 @@ function describeArrayTests(viewsRequireLifecycle) {
         expect(views[i].bindingContext.item.id).toBe(viewModel.items[i].id);
         expect(views[i].bindingContext.item.text).toBe(viewModel.items[i].text);
       }
-      
+
       let overrideContext = views[i].overrideContext;
       expect(overrideContext.parentOverrideContext.bindingContext).toBe(viewModel);
       expect(overrideContext.bindingContext).toBe(views[i].bindingContext);
@@ -184,7 +184,7 @@ function describeArrayTests(viewsRequireLifecycle) {
     // validate contextual data
     validateContextualData();
   }
-  
+
   function validateObjectState() {
     // validate DOM
     let expectedContent = viewModel.items.map(x => x === null || x === undefined ? '' : x.text.toString());
@@ -351,7 +351,7 @@ function describeArrayTests(viewsRequireLifecycle) {
       nq(() => done());
     });
   });
-  
+
   describe('reuse elements', () => {
     beforeEach(() => {
       let template = `<template><div repeat.for="item of items">\${item}</div></template>`;
@@ -736,7 +736,7 @@ function describeArrayTests(viewsRequireLifecycle) {
       nq(() => done());
     });
   });
-  
+
   describe('reuse elements with a matcher', () => {
     beforeEach(() => {
       let template = `<template><div repeat.for="item of items" matcher.bind="matcher">\${item.text}</div></template>`;
@@ -753,7 +753,7 @@ function describeArrayTests(viewsRequireLifecycle) {
       expect(hasSubscribers(viewModel, 'items')).toBe(false);
       expect(hasArraySubscribers(viewModel.items)).toBe(false);
     });
-    
+
     it('handles new items, same content', done => {
       let observer = observerLocator.getArrayObserver(viewModel.items);
       let divs;
@@ -866,7 +866,7 @@ function describeArrayTests(viewsRequireLifecycle) {
       nq(() => done());
     });
   });
-  
+
   describe('with converter that returns original instance', () => {
     beforeEach(() => {
       let template = `<template><div repeat.for="item of items | noopValueConverter">\${item}</div></template>`;


### PR DESCRIPTION
When I write test for my aurelia plugin [bcx-aurelia-reorderable-repeat](https://github.com/buttonwoodcx/bcx-aurelia-reorderable-repeat), I discovered the `createAssertionQueue` function I copied from [aurelia-ui-virtualization](https://github.com/aurelia/ui-virtualization) (it copied from this repo I guess) has bug.

I believe the intended behaviour for

```javascript
let nq = createAssertionQueue();
ng(work0); ng(work1); ng(work2);
```
is to run 3 works in serial, everyone is in different JavaScript runloop.

```
start -> work0() -> work1() -> work2()
```

But the existing implementation got it wrong. All 3 works runs in the same next JavaScript runloop;

```
start -> work0()
start -> work1()
start -> work2()
```

To demonstrate this issue, run following code in node. It uses 1 second delay in setTimeout for better illustration.

```javascript
function createAssertionQueue() {
  let queue = [];

  let next;
  next = () => {
    console.log('call next with queue size: '+queue.length);
    if (queue.length) {
      let func = queue.pop();
    
      setTimeout(() => {
        func();
        next();
      }, 1000);
    }
  };

  return func => {
    queue.push(func);
    if (queue.length === 1) {
      next();
    }
  };
}
let nq = createAssertionQueue();

nq(() => console.log('nq #0 ' + new Date)); nq(() => console.log('nq #1 ' + new Date)); nq(() => console.log('nq #2 ' + new Date));
```

It prints:
```
call next with queue size: 1
call next with queue size: 1
call next with queue size: 1

nq #0 Mon Jul 31 2017 17:34:14 GMT+1000 (AEST)
call next with queue size: 0
nq #1 Mon Jul 31 2017 17:34:14 GMT+1000 (AEST)
call next with queue size: 0
nq #2 Mon Jul 31 2017 17:34:14 GMT+1000 (AEST)
call next with queue size: 0
```

All 3 works excuted without delay in between. The bug is `next()` immediately do `queue.pop`, so `queue` size never actually grows to beyond 1.

This fix bring back intended behaviour. It now behaves like:
```
setTimeout(() => {
  work1();
  setTimeout(() => {
    work2();
    setTimeout(() => {
      work3();
    });
  });
});
```
