### PR TITLE
fix(if): resolve if.html error

### DIFF
--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -1,6 +1,7 @@
 import {PLATFORM} from 'aurelia-pal';
 import {Compose} from './compose';
 import {If} from './if';
+import {Else} from './else';
 import {With} from './with';
 import {Repeat} from './repeat';
 import {Show} from './show';
@@ -44,6 +45,7 @@ function configure(config) {
   config.globalResources(
     PLATFORM.moduleName('./compose'),
     PLATFORM.moduleName('./if'),
+    PLATFORM.moduleName('./else'),
     PLATFORM.moduleName('./with'),
     PLATFORM.moduleName('./repeat'),
     PLATFORM.moduleName('./show'),
@@ -74,6 +76,7 @@ function configure(config) {
 export {
   Compose,
   If,
+  Else,
   With,
   Repeat,
   Show,

--- a/src/else.js
+++ b/src/else.js
@@ -1,0 +1,30 @@
+import {BoundViewFactory, ViewSlot, bindable, customAttribute, templateController} from 'aurelia-templating';
+import {inject} from 'aurelia-dependency-injection';
+import {IfCore} from './if-core';
+
+@customAttribute('else')
+@templateController
+@inject(BoundViewFactory, ViewSlot)
+export class Else extends IfCore {
+  constructor(viewFactory, viewSlot) {
+    super(viewFactory, viewSlot);
+    this._registerInIf();
+  }
+
+  _registerInIf() {
+    // We support the pattern <div if.bind="x"></div><div else></div>.
+    // Obvisouly between the two, we must accepts text (spaces) and comments.
+    // The `if` node is expected to be a comment anchor, because of `@templateController`.
+    // To simplify the code we basically walk up to the first Aurelia predecessor,
+    // so having static tags in between (no binding) would work but is not intended to be supported.
+    let previous = this.viewSlot.anchor.previousSibling;
+    while (previous && !previous.au) {
+      previous = previous.previousSibling;
+    }
+    if (!previous || !previous.au.if) {
+      throw new Error("Can't find matching If for Else custom attribute.");
+    }
+    let ifVm = previous.au.if.viewModel;
+    ifVm.else = this;
+  }
+}

--- a/src/if-core.js
+++ b/src/if-core.js
@@ -1,0 +1,78 @@
+/**
+* For internal use only. May change without warning.
+*/
+export class IfCore {
+  constructor(viewFactory, viewSlot) {
+    this.viewFactory = viewFactory;
+    this.viewSlot = viewSlot;
+    this.view = null;
+    this.bindingContext = null;
+    this.overrideContext = null;
+    // If the child view is animated, `value` might not reflect the internal
+    // state anymore, so we use `showing` for that.
+    // Eventually, `showing` and `value` should be consistent.
+    this.showing = false;
+  }
+
+  bind(bindingContext, overrideContext) {
+    // Store parent bindingContext, so we can pass it down
+    this.bindingContext = bindingContext;
+    this.overrideContext = overrideContext;
+  }
+
+  unbind() {
+    if (this.view === null) {
+      return;
+    }
+
+    this.view.unbind();
+
+    // It seems to me that this code is subject to race conditions when animating.
+    // For example a view could be returned to the cache and reused while it's still
+    // attached to the DOM and animated.
+    if (!this.viewFactory.isCaching) {
+      return;
+    }
+
+    if (this.showing) {
+      this.showing = false;
+      this.viewSlot.remove(this.view, /*returnToCache:*/true, /*skipAnimation:*/true);
+    } else {
+      this.view.returnToCache();
+    }
+
+    this.view = null;
+  }
+
+  _show() {
+    if (this.showing) {
+      return;
+    }
+
+    if (this.view === null) {
+      this.view = this.viewFactory.create();
+    }
+
+    if (!this.view.isBound) {
+      this.view.bind(this.bindingContext, this.overrideContext);
+    }
+
+    this.showing = true;
+    return this.viewSlot.add(this.view); // Promise or void
+  }
+
+  _hide() {
+    if (!this.showing) {
+      return;
+    }
+
+    this.showing = false;
+    let removed = this.viewSlot.remove(this.view); // Promise or View
+
+    if (removed instanceof Promise) {
+      return removed.then(() => this.view.unbind());
+    }
+
+    this.view.unbind();
+  }
+}

--- a/src/if.js
+++ b/src/if.js
@@ -1,84 +1,6 @@
 import {BoundViewFactory, ViewSlot, bindable, customAttribute, templateController} from 'aurelia-templating';
 import {inject} from 'aurelia-dependency-injection';
-
-/**
-* For internal use only. May change without warning.
-*/
-export class IfCore {
-  constructor(viewFactory, viewSlot) {
-    this.viewFactory = viewFactory;
-    this.viewSlot = viewSlot;
-    this.view = null;
-    this.bindingContext = null;
-    this.overrideContext = null;
-    // If the child view is animated, `value` might not reflect the internal
-    // state anymore, so we use `showing` for that.
-    // Eventually, `showing` and `value` should be consistent.
-    this.showing = false;
-  }
-
-  bind(bindingContext, overrideContext) {
-    // Store parent bindingContext, so we can pass it down
-    this.bindingContext = bindingContext;
-    this.overrideContext = overrideContext;
-  }
-
-  unbind() {
-    if (this.view === null) {
-      return;
-    }
-
-    this.view.unbind();
-
-    // It seems to me that this code is subject to race conditions when animating.
-    // For example a view could be returned to the cache and reused while it's still
-    // attached to the DOM and animated.
-    if (!this.viewFactory.isCaching) {
-      return;
-    }
-
-    if (this.showing) {
-      this.showing = false;
-      this.viewSlot.remove(this.view, /*returnToCache:*/true, /*skipAnimation:*/true);
-    } else {
-      this.view.returnToCache();
-    }
-
-    this.view = null;
-  }
-
-  _show() {
-    if (this.showing) {
-      return;
-    }
-
-    if (this.view === null) {
-      this.view = this.viewFactory.create();
-    }
-
-    if (!this.view.isBound) {
-      this.view.bind(this.bindingContext, this.overrideContext);
-    }
-
-    this.showing = true;
-    return this.viewSlot.add(this.view); // Promise or void
-  }
-
-  _hide() {
-    if (!this.showing) {
-      return;
-    }
-
-    this.showing = false;
-    let removed = this.viewSlot.remove(this.view); // Promise or View
-
-    if (removed instanceof Promise) {
-      return removed.then(() => this.view.unbind());
-    }
-
-    this.view.unbind();
-  }
-}
+import {IfCore} from './if-core';
 
 /**
 * Binding to conditionally include or not include template logic depending on returned result
@@ -142,32 +64,5 @@ export class If extends IfCore {
       let promise = remove._hide();
       return promise ? promise.then(() => add._show()) : add._show();
     }
-  }
-}
-
-@customAttribute('else')
-@templateController
-@inject(BoundViewFactory, ViewSlot)
-export class Else extends IfCore {
-  constructor(viewFactory, viewSlot) {
-    super(viewFactory, viewSlot);
-    this._registerInIf();
-  }
-
-  _registerInIf() {
-    // We support the pattern <div if.bind="x"></div><div else></div>.
-    // Obvisouly between the two, we must accepts text (spaces) and comments.
-    // The `if` node is expected to be a comment anchor, because of `@templateController`.
-    // To simplify the code we basically walk up to the first Aurelia predecessor,
-    // so having static tags in between (no binding) would work but is not intended to be supported.
-    let previous = this.viewSlot.anchor.previousSibling;
-    while (previous && !previous.au) {
-      previous = previous.previousSibling;
-    }
-    if (!previous || !previous.au.if) {
-      throw new Error("Can't find matching If for Else custom attribute.");
-    }
-    let ifVm = previous.au.if.viewModel;
-    ifVm.else = this;
   }
 }


### PR DESCRIPTION
fixes https://github.com/aurelia/templating-resources/issues/312

Basically, we want to export custom elements and attributes in individual files. So I've moved `else` out of `if` and registered it in `aurelia-templating-resources.js`

built version is in branch: https://github.com/JeroenVinke/templating-resources/tree/else-own-file-built