### PR TITLE
fix(if-else): Fixed missing binding context when rendering else block

### DIFF
--- a/src/else.js
+++ b/src/else.js
@@ -13,11 +13,6 @@ export class Else extends IfCore {
 
   bind(bindingContext, overrideContext) {
     super.bind(bindingContext, overrideContext);
-
-    if (!this.ifVm) {
-      throw new Error('There must be a node with an if attribute before the else attribute');
-    }
-
     this.ifVm.conditionChanged(this.ifVm.condition);
   }
 
@@ -35,6 +30,6 @@ export class Else extends IfCore {
       throw new Error("Can't find matching If for Else custom attribute.");
     }
     this.ifVm = previous.au.if.viewModel;
-    this.ifVm.else = this;
+    this.ifVm.elseVm = this;
   }
 }

--- a/src/else.js
+++ b/src/else.js
@@ -13,7 +13,10 @@ export class Else extends IfCore {
 
   bind(bindingContext, overrideContext) {
     super.bind(bindingContext, overrideContext);
-    this.ifVm.conditionChanged(this.ifVm.condition);
+    // Render on initial
+    if (!this.ifVm.condition) {
+      this._show();
+    }
   }
 
   _registerInIf() {

--- a/src/else.js
+++ b/src/else.js
@@ -11,6 +11,16 @@ export class Else extends IfCore {
     this._registerInIf();
   }
 
+  bind(bindingContext, overrideContext) {
+    super.bind(bindingContext, overrideContext);
+
+    if (!this.ifVm) {
+      throw new Error('There must be a node with an if attribute before the else attribute');
+    }
+
+    this.ifVm.conditionChanged(this.ifVm.condition);
+  }
+
   _registerInIf() {
     // We support the pattern <div if.bind="x"></div><div else></div>.
     // Obvisouly between the two, we must accepts text (spaces) and comments.
@@ -24,7 +34,7 @@ export class Else extends IfCore {
     if (!previous || !previous.au.if) {
       throw new Error("Can't find matching If for Else custom attribute.");
     }
-    let ifVm = previous.au.if.viewModel;
-    ifVm.else = this;
+    this.ifVm = previous.au.if.viewModel;
+    this.ifVm.else = this;
   }
 }

--- a/src/if.js
+++ b/src/if.js
@@ -20,7 +20,10 @@ export class If extends IfCore {
   */
   bind(bindingContext, overrideContext) {
     super.bind(bindingContext, overrideContext);
-    this.conditionChanged(this.condition);
+    // Else attribute will trigger change when it's bound
+    if (!this.else || this.else.isBound) {
+      this.conditionChanged(this.condition);
+    }
   }
 
   /**

--- a/src/if.js
+++ b/src/if.js
@@ -21,7 +21,7 @@ export class If extends IfCore {
   bind(bindingContext, overrideContext) {
     super.bind(bindingContext, overrideContext);
     // Else attribute will trigger change when it's bound
-    if (!this.else || this.else.isBound) {
+    if (!this.elseVm || this.elseVm.isBound) {
       this.conditionChanged(this.condition);
     }
   }
@@ -40,8 +40,8 @@ export class If extends IfCore {
     }
 
     let promise;
-    if (this.else) {
-      promise = show ? this._swap(this.else, this) : this._swap(this, this.else);
+    if (this.elseVm) {
+      promise = show ? this._swap(this.elseVm, this) : this._swap(this, this.elseVm);
     } else {
       promise = show ? this._show() : this._hide();
     }

--- a/src/if.js
+++ b/src/if.js
@@ -20,9 +20,8 @@ export class If extends IfCore {
   */
   bind(bindingContext, overrideContext) {
     super.bind(bindingContext, overrideContext);
-    // Else attribute will trigger change when it's bound
-    if (!this.elseVm || this.elseVm.isBound) {
-      this.conditionChanged(this.condition);
+    if (this.condition) {
+      this._show();
     }
   }
 

--- a/test/else.spec.js
+++ b/test/else.spec.js
@@ -1,0 +1,155 @@
+import './setup';
+import {ViewSlot} from 'aurelia-templating';
+import {If} from '../src/if';
+import {Else} from '../src/else';
+
+class ViewMock {
+  bind() {}
+  unbind() {}
+}
+
+describe('else', () => {
+  let ifViewSlot, elseViewSlot, ifVm, elseVm, viewFactory;
+
+  beforeEach(() => {
+    const fragment = document.createDocumentFragment();
+    const ifNode = document.createElement('div');
+    const elseNode = document.createElement('div');
+    fragment.appendChild(ifNode);
+    fragment.appendChild(elseNode);
+    ifViewSlot = new ViewSlot(ifNode, true);
+    elseViewSlot = new ViewSlot(elseNode, true);
+    ifVm = new If(viewFactory, ifViewSlot);
+    ifVm.view = new ViewMock();
+    ifNode.au = {if: {viewModel: ifVm}};
+
+    elseVm = new Else(viewFactory, elseViewSlot);
+    elseVm.view = new ViewMock();
+  });
+
+  fit('should render when initial condition is false', () => {
+    ifVm.showing = false;
+    elseVm.showing = false;
+
+    spyOn(ifViewSlot, 'add');
+    spyOn(ifVm.view, 'bind');
+    spyOn(elseViewSlot, 'add');
+    spyOn(elseVm.view, 'bind');
+
+    ifVm.condition = false;
+    ifVm.bind();
+    // Nothing should happen yet since else is not bound yet
+    expect(ifViewSlot.add).not.toHaveBeenCalled();
+    expect(ifVm.view.bind).not.toHaveBeenCalled();
+    expect(elseViewSlot.add).not.toHaveBeenCalled();
+    expect(elseVm.view.bind).not.toHaveBeenCalled();
+
+    elseVm.isBound = true;
+    elseVm.bind();
+    // Else should be shown now
+    expect(ifVm.showing).toBeFalsy();
+    expect(ifViewSlot.add).not.toHaveBeenCalled();
+    expect(ifVm.view.bind).not.toHaveBeenCalled();
+    expect(elseVm.showing).toBeTruthy();
+    expect(elseViewSlot.add).toHaveBeenCalled();
+    expect(elseVm.view.bind).toHaveBeenCalled();
+  });
+
+  fit('should not render when initial condition is true', () => {
+    ifVm.showing = false;
+    elseVm.showing = false;
+
+    spyOn(elseViewSlot, 'add');
+    spyOn(elseVm.view, 'bind');
+    spyOn(ifViewSlot, 'add');
+    spyOn(ifVm.view, 'bind');
+
+    ifVm.condition = true;
+    ifVm.bind();
+    // Nothing should happen yet since else is not bound yet
+    expect(elseViewSlot.add).not.toHaveBeenCalled();
+    expect(elseVm.view.bind).not.toHaveBeenCalled();
+    expect(ifViewSlot.add).not.toHaveBeenCalled();
+    expect(ifVm.view.bind).not.toHaveBeenCalled();
+
+    elseVm.isBound = true;
+    elseVm.bind();
+    // If should be shown now
+    expect(elseVm.showing).toBeFalsy();
+    expect(elseViewSlot.add).not.toHaveBeenCalled(); // Was not added yet
+    expect(elseVm.view.bind).not.toHaveBeenCalled(); // Was not added yet
+    expect(ifVm.showing).toBeTruthy();
+    expect(ifViewSlot.add).toHaveBeenCalled();
+    expect(ifVm.view.bind).toHaveBeenCalled();
+  });
+
+  fit('should render when condition changes to false', () => {
+    ifVm.showing = false;
+    elseVm.showing = false;
+
+    spyOn(ifViewSlot, 'add');
+    spyOn(ifVm.view, 'bind');
+    spyOn(ifViewSlot, 'remove');
+    spyOn(ifVm.view, 'unbind');
+    spyOn(elseViewSlot, 'add');
+    spyOn(elseVm.view, 'bind');
+
+    ifVm.condition = true;
+    ifVm.bind();
+    elseVm.isBound = true;
+    elseVm.bind();
+    // Nothing should happen yet since else is not bound yet
+    expect(ifVm.showing).toBeTruthy();
+    expect(ifViewSlot.add).toHaveBeenCalled();
+    expect(ifVm.view.bind).toHaveBeenCalled();
+    expect(elseVm.showing).toBeFalsy();
+    expect(elseViewSlot.add).not.toHaveBeenCalled();
+    expect(elseVm.view.bind).not.toHaveBeenCalled();
+
+    ifVm.condition = false;
+    ifVm.bind();
+
+    // Else should be shown now and if should be removed
+    expect(ifVm.showing).toBeFalsy();
+    expect(ifViewSlot.remove).toHaveBeenCalled(); // Was not added yet
+    expect(ifVm.view.unbind).toHaveBeenCalled(); // Was not added yet
+    expect(elseVm.showing).toBeTruthy();
+    expect(elseViewSlot.add).toHaveBeenCalled();
+    expect(elseVm.view.bind).toHaveBeenCalled();
+  });
+
+  fit('should render when condition changes to true', () => {
+    ifVm.showing = false;
+    elseVm.showing = false;
+
+    spyOn(ifViewSlot, 'add');
+    spyOn(ifVm.view, 'bind');
+    spyOn(elseViewSlot, 'add');
+    spyOn(elseVm.view, 'bind');
+    spyOn(elseViewSlot, 'remove');
+    spyOn(elseVm.view, 'unbind');
+
+    ifVm.condition = false;
+    ifVm.bind();
+    elseVm.isBound = true;
+    elseVm.bind();
+    // Nothing should happen yet since else is not bound yet
+    expect(ifVm.showing).toBeFalsy();
+    expect(ifViewSlot.add).not.toHaveBeenCalled();
+    expect(ifVm.view.bind).not.toHaveBeenCalled();
+    expect(elseVm.showing).toBeTruthy();
+    expect(elseViewSlot.add).toHaveBeenCalled();
+    expect(elseVm.view.bind).toHaveBeenCalled();
+
+    ifVm.condition = true;
+    ifVm.bind();
+
+    // Else should be shown now and if should be removed
+    expect(ifVm.showing).toBeTruthy();
+    expect(ifViewSlot.add).toHaveBeenCalled(); // Was not added yet
+    expect(ifVm.view.bind).toHaveBeenCalled(); // Was not added yet
+    expect(elseVm.showing).toBeFalsy();
+    expect(elseViewSlot.remove).toHaveBeenCalled();
+    expect(elseVm.view.unbind).toHaveBeenCalled();
+  });
+});

--- a/test/else.spec.js
+++ b/test/else.spec.js
@@ -38,21 +38,14 @@ describe('else', () => {
 
     ifVm.condition = false;
     ifVm.bind();
-    // Nothing should happen yet since else is not bound yet
-    expect(ifViewSlot.add).not.toHaveBeenCalled();
-    expect(ifVm.view.bind).not.toHaveBeenCalled();
-    expect(elseViewSlot.add).not.toHaveBeenCalled();
-    expect(elseVm.view.bind).not.toHaveBeenCalled();
-
-    elseVm.isBound = true;
     elseVm.bind();
     // Else should be shown now
     expect(ifVm.showing).toBeFalsy();
     expect(ifViewSlot.add).not.toHaveBeenCalled();
     expect(ifVm.view.bind).not.toHaveBeenCalled();
     expect(elseVm.showing).toBeTruthy();
-    expect(elseViewSlot.add).toHaveBeenCalled();
-    expect(elseVm.view.bind).toHaveBeenCalled();
+    expect(elseViewSlot.add).toHaveBeenCalledTimes(1);
+    expect(elseVm.view.bind).toHaveBeenCalledTimes(1);
   });
 
   it('should not render when initial condition is true', () => {
@@ -66,21 +59,14 @@ describe('else', () => {
 
     ifVm.condition = true;
     ifVm.bind();
-    // Nothing should happen yet since else is not bound yet
-    expect(elseViewSlot.add).not.toHaveBeenCalled();
-    expect(elseVm.view.bind).not.toHaveBeenCalled();
-    expect(ifViewSlot.add).not.toHaveBeenCalled();
-    expect(ifVm.view.bind).not.toHaveBeenCalled();
-
-    elseVm.isBound = true;
     elseVm.bind();
     // If should be shown now
     expect(elseVm.showing).toBeFalsy();
     expect(elseViewSlot.add).not.toHaveBeenCalled(); // Was not added yet
     expect(elseVm.view.bind).not.toHaveBeenCalled(); // Was not added yet
     expect(ifVm.showing).toBeTruthy();
-    expect(ifViewSlot.add).toHaveBeenCalled();
-    expect(ifVm.view.bind).toHaveBeenCalled();
+    expect(ifViewSlot.add).toHaveBeenCalledTimes(1);
+    expect(ifVm.view.bind).toHaveBeenCalledTimes(1);
   });
 
   it('should render when condition changes to false', () => {
@@ -96,26 +82,25 @@ describe('else', () => {
 
     ifVm.condition = true;
     ifVm.bind();
-    elseVm.isBound = true;
     elseVm.bind();
     // Nothing should happen yet since else is not bound yet
     expect(ifVm.showing).toBeTruthy();
-    expect(ifViewSlot.add).toHaveBeenCalled();
-    expect(ifVm.view.bind).toHaveBeenCalled();
+    expect(ifViewSlot.add).toHaveBeenCalledTimes(1);
+    expect(ifVm.view.bind).toHaveBeenCalledTimes(1);
     expect(elseVm.showing).toBeFalsy();
     expect(elseViewSlot.add).not.toHaveBeenCalled();
     expect(elseVm.view.bind).not.toHaveBeenCalled();
 
     ifVm.condition = false;
-    ifVm.bind();
+    ifVm.conditionChanged(false);
 
     // Else should be shown now and if should be removed
     expect(ifVm.showing).toBeFalsy();
-    expect(ifViewSlot.remove).toHaveBeenCalled(); // Was not added yet
-    expect(ifVm.view.unbind).toHaveBeenCalled(); // Was not added yet
+    expect(ifViewSlot.remove).toHaveBeenCalledTimes(1);
+    expect(ifVm.view.unbind).toHaveBeenCalledTimes(1);
     expect(elseVm.showing).toBeTruthy();
-    expect(elseViewSlot.add).toHaveBeenCalled();
-    expect(elseVm.view.bind).toHaveBeenCalled();
+    expect(elseViewSlot.add).toHaveBeenCalledTimes(1);
+    expect(elseVm.view.bind).toHaveBeenCalledTimes(1);
   });
 
   it('should render when condition changes to true', () => {
@@ -131,25 +116,24 @@ describe('else', () => {
 
     ifVm.condition = false;
     ifVm.bind();
-    elseVm.isBound = true;
     elseVm.bind();
     // Nothing should happen yet since else is not bound yet
     expect(ifVm.showing).toBeFalsy();
     expect(ifViewSlot.add).not.toHaveBeenCalled();
     expect(ifVm.view.bind).not.toHaveBeenCalled();
     expect(elseVm.showing).toBeTruthy();
-    expect(elseViewSlot.add).toHaveBeenCalled();
-    expect(elseVm.view.bind).toHaveBeenCalled();
+    expect(elseViewSlot.add).toHaveBeenCalledTimes(1);
+    expect(elseVm.view.bind).toHaveBeenCalledTimes(1);
 
     ifVm.condition = true;
-    ifVm.bind();
+    ifVm.conditionChanged(true);
 
     // Else should be shown now and if should be removed
     expect(ifVm.showing).toBeTruthy();
-    expect(ifViewSlot.add).toHaveBeenCalled(); // Was not added yet
-    expect(ifVm.view.bind).toHaveBeenCalled(); // Was not added yet
+    expect(ifViewSlot.add).toHaveBeenCalledTimes(1);
+    expect(ifVm.view.bind).toHaveBeenCalledTimes(1);
     expect(elseVm.showing).toBeFalsy();
-    expect(elseViewSlot.remove).toHaveBeenCalled();
-    expect(elseVm.view.unbind).toHaveBeenCalled();
+    expect(elseViewSlot.remove).toHaveBeenCalledTimes(1);
+    expect(elseVm.view.unbind).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/else.spec.js
+++ b/test/else.spec.js
@@ -27,7 +27,7 @@ describe('else', () => {
     elseVm.view = new ViewMock();
   });
 
-  fit('should render when initial condition is false', () => {
+  it('should render when initial condition is false', () => {
     ifVm.showing = false;
     elseVm.showing = false;
 
@@ -55,7 +55,7 @@ describe('else', () => {
     expect(elseVm.view.bind).toHaveBeenCalled();
   });
 
-  fit('should not render when initial condition is true', () => {
+  it('should not render when initial condition is true', () => {
     ifVm.showing = false;
     elseVm.showing = false;
 
@@ -83,7 +83,7 @@ describe('else', () => {
     expect(ifVm.view.bind).toHaveBeenCalled();
   });
 
-  fit('should render when condition changes to false', () => {
+  it('should render when condition changes to false', () => {
     ifVm.showing = false;
     elseVm.showing = false;
 
@@ -118,7 +118,7 @@ describe('else', () => {
     expect(elseVm.view.bind).toHaveBeenCalled();
   });
 
-  fit('should render when condition changes to true', () => {
+  it('should render when condition changes to true', () => {
     ifVm.showing = false;
     elseVm.showing = false;
 


### PR DESCRIPTION
Issue: #322 

This PR fixes the issue that an else block is rendered without a bindingContext in case that the condition is falsy and the view is rendered initially.
I also added some simple unit tests to check if the correct block is rendered and the swapping logic works properly.

