### PR TITLE
fix(if): fix nested if bindings

### DIFF
--- a/src/if-core.js
+++ b/src/if-core.js
@@ -31,7 +31,6 @@ export class IfCore {
     // For example a view could be returned to the cache and reused while it's still
     // attached to the DOM and animated.
     if (!this.viewFactory.isCaching) {
-	    this.showing = false;
       return;
     }
 
@@ -45,8 +44,8 @@ export class IfCore {
     this.view = null;
   }
 
-  _show() {
-    if (this.showing) {
+  _show(force) {
+    if (this.showing && !force) {
       return;
     }
 

--- a/src/if.js
+++ b/src/if.js
@@ -21,7 +21,7 @@ export class If extends IfCore {
   bind(bindingContext, overrideContext) {
     super.bind(bindingContext, overrideContext);
     if (this.condition) {
-      this._show();
+      this._show(true);
     }
   }
 

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -63,25 +63,6 @@ describe('if', () => {
     expect(sut.view).toBeNull();
   });
 
-  it('should correctly unbind view without removing it when viewFactory is caching and being unbound itself', () => {
-    let view = new ViewMock();
-    sut.view = view;
-    sut.showing = true;
-    viewFactory.isCaching = false;
-    spyOn(viewSlot, 'remove');
-    spyOn(view, 'unbind');
-    spyOn(view, 'returnToCache');
-
-    sut.unbind();
-    taskQueue.flushMicroTaskQueue();
-
-    expect(sut.showing).toBeFalsy();
-    expect(view.unbind).toHaveBeenCalled();
-    expect(viewSlot.remove).not.toHaveBeenCalled();
-    expect(view.returnToCache).not.toHaveBeenCalled();
-    expect(sut.view).not.toBeNull();
-  });
-
   it('should do nothing when not showing and provided value is falsy', () => {
     let view = new ViewMock();
     sut.view = view;
@@ -120,6 +101,21 @@ describe('if', () => {
 
     expect(viewFactory.create).toHaveBeenCalled();
     expect(newView.bind).toHaveBeenCalledWith(42, 24);
+  });
+
+  it('should rebind view if it\'s not bound when being bound itself', () => {
+    sut.condition = true;
+    sut.showing = true;
+    sut.view = {isBound: false, bind: jasmine.createSpy('bind')};
+    let bindingContext = 42;
+    let overrideContext = 24;
+
+    spyOn(sut, '_show').and.callThrough();
+
+    sut.bind(bindingContext, overrideContext);
+
+    expect(sut._show).toHaveBeenCalledWith(true);
+    expect(sut.view.bind).toHaveBeenCalledWith(42, 24);
   });
 
   it('should show the view when provided value is truthy and currently not showing', () => {

--- a/test/repeat.spec.js
+++ b/test/repeat.spec.js
@@ -69,7 +69,7 @@ describe('repeat', () => {
       spyOn(viewSlot, 'removeAll');
       repeat.unbind();
 
-      expect(viewSlot.removeAll).toHaveBeenCalledWith(true);
+      expect(viewSlot.removeAll).toHaveBeenCalledWith(true, true);
     });
 
     it('should unsubscribe collection', () => {


### PR DESCRIPTION
- Revert (flawed) fix from #324
- Force rebind of view (if not bound) if the if-binding is rebound and condition is `true`
- Fix unit-tests for repeat, which were failing because of work done in #303

Closes #328