### PR TITLE
feature(dirty-binding-behavior): Add the dirty binding behavior

### DIFF
--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -18,6 +18,7 @@ import {ThrottleBindingBehavior} from './throttle-binding-behavior';
 import {DebounceBindingBehavior} from './debounce-binding-behavior';
 import {SelfBindingBehavior} from './self-binding-behavior';
 import {SignalBindingBehavior} from './signal-binding-behavior';
+import {DirtyBindingBehavior} from './dirty-binding-behavior';
 import {BindingSignaler} from './binding-signaler';
 import {UpdateTriggerBindingBehavior} from './update-trigger-binding-behavior';
 import {AbstractRepeater} from './abstract-repeater';
@@ -58,6 +59,7 @@ function configure(config) {
     PLATFORM.moduleName('./throttle-binding-behavior'),
     PLATFORM.moduleName('./debounce-binding-behavior'),
     PLATFORM.moduleName('./signal-binding-behavior'),
+    PLATFORM.moduleName('./dirty-binding-behavior'),
     PLATFORM.moduleName('./update-trigger-binding-behavior'),
     PLATFORM.moduleName('./attr-binding-behavior')
   );
@@ -94,6 +96,7 @@ export {
   DebounceBindingBehavior,
   SelfBindingBehavior,
   SignalBindingBehavior,
+  DirtyBindingBehavior,
   BindingSignaler,
   UpdateTriggerBindingBehavior,
   AbstractRepeater,

--- a/src/dirty-binding-behavior.js
+++ b/src/dirty-binding-behavior.js
@@ -1,0 +1,41 @@
+function evaluate(binding, source) {
+  return binding.sourceExpression.evaluate(source, binding.lookupFunctions);
+}
+
+export class DirtyBindingBehavior {
+
+  timer;
+  updateTarget;
+  
+  bind(binding, source, frequency = 100) {  
+
+    // intercept the updateTarget function, reference it locally, and unset it
+    // on the binding since we will handle all of the updates
+    this.updateTarget = binding.updateTarget;
+    let updateTarget = binding.updateTarget.bind(binding);
+    binding.updateTarget = () => {};
+
+    // track the current value and call updateTarget with the current value
+    let oldValue = evaluate(binding, source);
+    updateTarget(oldValue);
+
+    this.timer = setInterval(() => {
+
+      // get the new current value
+      let newValue = evaluate(binding, source);
+
+      // if the value has changed, call updateTarget with the new value and 
+      // store the new value as the current value
+      if (newValue !== oldValue) {
+        updateTarget(newValue);
+        oldValue = newValue;
+      }
+    }, frequency);
+  }
+ 
+  unbind(binding, source) {
+    clearInterval(this.timer);
+    binding.updateTarget = this.updateTarget;
+  }
+}
+


### PR DESCRIPTION
When binding arbitrary expressions that depend on complex objects there are no tools to either observe the dependencies or force a regular update. The dirty binding behavior adds a binding behavior that overrides the default binding and instead forces regular updates. The default update interval is 100ms, which research has shown is the threshold for an action to be perceived as instantaneous (see here: https://ux.stackexchange.com/questions/2/what-is-an-acceptable-response-time-for-my-ajax-ui/4#4). Developers can customize the responsiveness of the binding behavior by specifying a different update interval in ms as a parameter of the binding behavior.

Examples:

```html
<div>100ms, or 10fps: ${obj | toJson & dirty}</div>
<div>16ms, or 60fps: ${obj | toJson & dirty: 16}</div>
```