### PR TITLE
Added 'else' to lifecycleOptionalBehaviors in analyze-view-factory

### DIFF
--- a/src/analyze-view-factory.js
+++ b/src/analyze-view-factory.js
@@ -2,7 +2,7 @@
 * Behaviors that do not require the composition lifecycle callbacks when replacing
 * their binding context.
 */
-export const lifecycleOptionalBehaviors = ['focus', 'if', 'repeat', 'show', 'with'];
+export const lifecycleOptionalBehaviors = ['focus', 'if', 'else', 'repeat', 'show', 'with'];
 
 function behaviorRequiresLifecycle(instruction) {
   let t = instruction.type;


### PR DESCRIPTION
The 'else' attribute was added to aurelia-templating-resources 1.5.0, but seems like it was left out from the 'livecycleOptionBehaviors'. This leads to unnecessary work when removing av view from the DOM that uses the 'else' attribute.