### PR TITLE
fix(debounce): debounce binding call instead updatesource

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,12 @@
 System.config({
   defaultJSExtensions: true,
+  transpiler: "babel",
+  babelOptions: {
+    "optional": [
+      "runtime",
+      "optimisation.modules.system"
+    ]
+  },
   paths: {
     "github:*": "jspm_packages/github/*",
     "aurelia-templating-resources/*": "dist/*",
@@ -7,7 +14,7 @@ System.config({
   },
 
   map: {
-    "aurelia-binding": "npm:aurelia-binding@1.5.0",
+    "aurelia-binding": "npm:aurelia-binding@1.6.0",
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0-rc.1.0.1",
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
     "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0",
@@ -15,7 +22,7 @@ System.config({
     "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0",
     "aurelia-loader": "npm:aurelia-loader@1.0.0",
     "aurelia-loader-default": "npm:aurelia-loader-default@1.0.0",
-    "aurelia-logging": "npm:aurelia-logging@1.3.1",
+    "aurelia-logging": "npm:aurelia-logging@1.4.0",
     "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
     "aurelia-pal": "npm:aurelia-pal@1.4.0",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0",
@@ -54,8 +61,8 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "util": "npm:util@0.10.3"
     },
-    "npm:aurelia-binding@1.5.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+    "npm:aurelia-binding@1.6.0": {
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.4.0",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.2.1"
@@ -81,13 +88,13 @@ System.config({
       "aurelia-pal": "npm:aurelia-pal@1.4.0"
     },
     "npm:aurelia-event-aggregator@1.0.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1"
+      "aurelia-logging": "npm:aurelia-logging@1.4.0"
     },
     "npm:aurelia-framework@1.0.0-rc.1.0.13": {
-      "aurelia-binding": "npm:aurelia-binding@1.5.0",
+      "aurelia-binding": "npm:aurelia-binding@1.6.0",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.4.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
@@ -108,7 +115,7 @@ System.config({
       "aurelia-path": "npm:aurelia-path@1.1.1"
     },
     "npm:aurelia-logging-console@1.0.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1"
+      "aurelia-logging": "npm:aurelia-logging@1.4.0"
     },
     "npm:aurelia-metadata@1.0.3": {
       "aurelia-pal": "npm:aurelia-pal@1.4.0"
@@ -126,7 +133,7 @@ System.config({
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0",
       "aurelia-history": "npm:aurelia-history@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.0.0"
     },
@@ -134,15 +141,15 @@ System.config({
       "aurelia-pal": "npm:aurelia-pal@1.4.0"
     },
     "npm:aurelia-templating-binding@1.0.0-rc.1.0.1": {
-      "aurelia-binding": "npm:aurelia-binding@1.5.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-binding": "npm:aurelia-binding@1.6.0",
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-templating": "npm:aurelia-templating@1.3.0"
     },
     "npm:aurelia-templating-resources@1.0.0-rc.1.0.2": {
-      "aurelia-binding": "npm:aurelia-binding@1.5.0",
+      "aurelia-binding": "npm:aurelia-binding@1.6.0",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.4.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
@@ -151,7 +158,7 @@ System.config({
     },
     "npm:aurelia-templating-router@1.0.0-rc.1.0.1": {
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.4.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
@@ -159,10 +166,10 @@ System.config({
       "aurelia-templating": "npm:aurelia-templating@1.3.0"
     },
     "npm:aurelia-templating@1.3.0": {
-      "aurelia-binding": "npm:aurelia-binding@1.5.0",
+      "aurelia-binding": "npm:aurelia-binding@1.6.0",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.4.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
@@ -171,7 +178,7 @@ System.config({
     "npm:aurelia-testing@0.5.0": {
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
       "aurelia-framework": "npm:aurelia-framework@1.0.0-rc.1.0.13",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.4.0",
       "aurelia-pal": "npm:aurelia-pal@1.4.0",
       "aurelia-templating": "npm:aurelia-templating@1.3.0"
     },

--- a/src/update-trigger-binding-behavior.js
+++ b/src/update-trigger-binding-behavior.js
@@ -1,7 +1,7 @@
-import {bindingMode, EventManager} from 'aurelia-binding';
+import { bindingMode, EventManager } from 'aurelia-binding';
 
 const eventNamesRequired = 'The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:\'blur\'">';
-const notApplicableMessage = 'The updateTrigger binding behavior can only be applied to two-way bindings on input/select elements.';
+const notApplicableMessage = 'The updateTrigger binding behavior can only be applied to two-way/ from-view bindings on input/select elements.';
 
 export class UpdateTriggerBindingBehavior {
   static inject = [EventManager];
@@ -14,7 +14,7 @@ export class UpdateTriggerBindingBehavior {
     if (events.length === 0) {
       throw new Error(eventNamesRequired);
     }
-    if (binding.mode !== bindingMode.twoWay) {
+    if (binding.mode !== bindingMode.twoWay && binding.mode !== bindingMode.fromView) {
       throw new Error(notApplicableMessage);
     }
 


### PR DESCRIPTION
I tried to fix the throttle but pretty much gave up on the test. I think we should fix debounce first, regardless throttle status.

resolves #319
fixes aurelia/binding#625
fixes aurelia/binding#485

The gist of throttle working is here https://gist.run/?id=4fec87bd40bdfbd7ed10e7ad8f37fdd8 But I couldn't apply jasmin clock against it.

@jdanyow 