### PR TITLE
fix(UpdateTrigger): sync with binding

### DIFF
--- a/src/update-trigger-binding-behavior.js
+++ b/src/update-trigger-binding-behavior.js
@@ -1,14 +1,9 @@
-import { bindingMode, EventManager } from 'aurelia-binding';
+import { bindingMode, EventSubscriber } from 'aurelia-binding';
 
 const eventNamesRequired = 'The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:\'blur\'">';
 const notApplicableMessage = 'The updateTrigger binding behavior can only be applied to two-way/ from-view bindings on input/select elements.';
 
 export class UpdateTriggerBindingBehavior {
-  static inject = [EventManager];
-
-  constructor(eventManager) {
-    this.eventManager = eventManager;
-  }
 
   bind(binding, source, ...events) {
     if (events.length === 0) {
@@ -29,12 +24,13 @@ export class UpdateTriggerBindingBehavior {
     targetObserver.originalHandler = binding.targetObserver.handler;
 
     // replace the element subscribe function with one that uses the correct events.
-    let handler = this.eventManager.createElementHandler(events);
+    let handler = new EventSubscriber(events);
     targetObserver.handler = handler;
   }
 
   unbind(binding, source) {
     // restore the state of the binding.
+    binding.targetObserver.handler.dispose();
     binding.targetObserver.handler = binding.targetObserver.originalHandler;
     binding.targetObserver.originalHandler = null;
   }

--- a/test/update-trigger-binding-behavior.spec.js
+++ b/test/update-trigger-binding-behavior.spec.js
@@ -28,9 +28,9 @@ describe('UpdateTriggerBindingBehavior', () => {
     let target = document.createElement('input');
     let bindingExpression = bindingEngine.createBindingExpression('value', `foo & updateTrigger:'blur':'paste'`, bindingMode.twoWay, lookupFunctions);
     let binding = bindingExpression.createBinding(target);
-    let originalHandler = binding.targetProperty.handler;
 
     binding.bind(scope);
+    let targetHandler = binding.targetObserver.handler;
 
     target.value = 'baz';
     target.dispatchEvent(DOM.createCustomEvent('change'));
@@ -44,8 +44,16 @@ describe('UpdateTriggerBindingBehavior', () => {
     target.dispatchEvent(DOM.createCustomEvent('paste'));
     expect(source.foo).toBe('bang');
 
+
     binding.unbind();
 
-    expect(binding.targetProperty.handler).toBe(originalHandler);
+    target.value = 'target';
+    target.dispatchEvent(DOM.createCustomEvent('blur'));
+    expect(source.foo).toBe('bang');
+    target.dispatchEvent(DOM.createCustomEvent('paste'));
+    expect(source.foo).toBe('bang');
+
+    // also makes sure we disposed the listeners
+    expect(targetHandler.element).toBe(null);
   });
 });


### PR DESCRIPTION
- Ensure we dispose the listener before resetting the handler back to its original version.
- Use `EventSubscriber`

@EisenbergEffect this requires `aurelia-binding@1.7.x` and the fix at aurelia/binding#674