### PR TITLE
feat(css-resource): add configuration option to remove injected styles

### DIFF
--- a/doc/article/en-US/remove-injected-styles.md
+++ b/doc/article/en-US/remove-injected-styles.md
@@ -1,0 +1,21 @@
+## Removing custom element injected styles
+
+When you have a style resource associated with a custom element, a style node containing the CSS is injected into the document's `<head>` node. Normally that style node will stay there, even after the custom element is detached from the DOM. Browser support for `as-scoped` and `ShadowDOM` is still thin and thus there is no easy way to remove injected styles again.
+
+[This PR](https://github.com/aurelia/templating-resources/pull/344) is an attempt to address that. The behavior needs to be turned on explicitly in your `main` file where aurelia is configured. This is done by replacing  `au.use.standardConfiguration()` with the following explicit configuration:
+
+```ts
+au.use
+  .defaultBindingLanguage()
+  .history()
+  .router()
+  .eventAggregator()
+  // This also replaces the .standardResources() call
+  .plugin(PLATFORM.moduleName('aurelia-templating-resources'), opts => {
+    opts.removeInjectedStylesOnBeforeUnbind = true;
+  });
+```
+
+This will enable the behavior globally. Per-element (or other context) configuration may be considered if there seems to be a demand.
+
+Please note that this should be considered an experimental feature and needs thorough testing before going in production. There may also be performance implications. Should you encounter any issues, feel free to leave a comment [here](https://github.com/aurelia/templating-resources/pull/344).

--- a/src/aurelia-templating-resources.js
+++ b/src/aurelia-templating-resources.js
@@ -39,7 +39,11 @@ import {
 import {viewsRequireLifecycle} from './analyze-view-factory';
 import {injectAureliaHideStyleAtHead} from './aurelia-hide-style';
 
-function configure(config) {
+function configure(config, configureOptions) {
+  const options = { removeInjectedStylesOnBeforeUnbind: false };
+  if (typeof configureOptions === 'function') {
+    configureOptions(options);
+  }
   injectAureliaHideStyleAtHead();
 
   config.globalResources(
@@ -67,7 +71,7 @@ function configure(config) {
   let viewEngine = config.container.get(ViewEngine);
   let styleResourcePlugin = {
     fetch(address) {
-      return { [address]: _createCSSResource(address) };
+      return { [address]: _createCSSResource(address, options.removeInjectedStylesOnBeforeUnbind) };
     }
   };
   ['.css', '.less', '.sass', '.scss', '.styl'].forEach(ext => viewEngine.addResourcePlugin(ext, styleResourcePlugin));


### PR DESCRIPTION
This feature is requested now and then, and I'd also like to have it myself. It's probably not the cleanest solution, but I've tested it locally with webpack and works fine.

It's opt-in and will not change anything for existing applications.

Usage requires manually configuring aurelia and passing in the option, like so:

```ts
au.use
  .defaultBindingLanguage()
  .history()
  .router()
  .eventAggregator();
au.use.plugin(PLATFORM.moduleName('aurelia-templating-resources'), (opts: any) => {
  opts.removeInjectedStylesOnBeforeUnbind = true;
});
```

What this option will do is register the ViewEngineHooks (which normally only happens for `as="scoped"`), keep track of the injected StyleNode and remove it on `beforeUnbind`.

Since removing it will actually keep it removed across re-visits, it will add it again on `beforeBind` in case it hasn't been added yet by `beforeCompile`.

I also spotted a bug in the existing code: `} else if (this._global && !this.owner._alreadyGloballyInjected)`. It's possible that this prevented `as="scoped"` from working correctly. I changed `this._global` to `this.owner._global` which should fix that as well.
