### PR TITLE
fix(compose): rethrow instead of logging fix #346

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -8,8 +8,6 @@ import {
 } from 'aurelia-templating';
 import {DOM} from 'aurelia-pal';
 
-const logger = LogManager.getLogger('templating-resources');
-
 /**
 * Used to compose a new view / view-model template or bind to an existing instance.
 */
@@ -191,14 +189,20 @@ function processChanges(composer: Compose) {
     });
   }
 
-  composer.pendingTask = composer.pendingTask.catch(e => {
-    logger.error(e);
-  }).then(() => {
-    composer.pendingTask = null;
-    if (!isEmpty(composer.changes)) {
-      processChanges(composer);
-    }
-  });
+  composer.pendingTask = composer.pendingTask
+    .then(() => {
+      completeCompositionTask(composer);
+    }, reason => {
+      completeCompositionTask(composer);
+      throw reason;
+    });
+}
+
+function completeCompositionTask(composer) {
+  composer.pendingTask = null;
+  if (!isEmpty(composer.changes)) {
+    processChanges(composer);
+  }
 }
 
 function requestUpdate(composer: Compose) {

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -2,7 +2,6 @@ import './setup';
 import { TaskQueue } from 'aurelia-task-queue';
 import { Compose } from '../src/compose';
 import * as LogManager from 'aurelia-logging';
-const logger = LogManager.getLogger('templating-resources');
 
 describe('Compose', () => {
   let elementMock;
@@ -373,25 +372,24 @@ describe('Compose', () => {
   describe('after failing a composition', () => {
     let error;
     beforeEach(done => {
-      spyOn(logger, 'error');
       compositionEngineMock.compose.and.stub;
       compositionEngineMock.compose.and.callFake(() => Promise.reject(error = new Error('".compose" test error')));
       updateBindable('viewModel', './some-vm');
       taskQueue.queueMicroTask(done);
     });
 
-    it('logs the error', done => {
-      sut.pendingTask.then(() => {
-        expect(logger.error).toHaveBeenCalledWith(error);
+    it('re-throws errors', done => {
+      sut.pendingTask.then(() => done.fail('"pendingTask" should be rejected'), reason => {
+        expect(reason).toBe(error);
         done();
-      }).catch(done.fail);
+      });
     });
 
-    it('clears pending composition', done => {
-      sut.pendingTask.then(() => {
+    it('completes pending composition', done => {
+      sut.pendingTask.then(() => done.fail('"pendingTask" should be rejected'), () => {
         expect(sut.pendingTask).not.toBeTruthy();
         done();
-      }).catch(done.fail);
+      });
     });
   });
 });


### PR DESCRIPTION
Rethrow composition errors instead of logging them as errors.
Will result in unhandled Promise rejection.