### PR TITLE
Updated dependencies for aurelia-binding (removed 1.x dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "dist": "dist/amd"
     },
     "peerDependencies": {
-      "aurelia-binding": "^1.7.1 || ^2.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-loader": "^1.0.0",
       "aurelia-logging": "^1.0.0",
@@ -39,7 +39,7 @@
       "aurelia-templating": "^1.5.0"
     },
     "dependencies": {
-      "aurelia-binding": "^1.7.1 || ^2.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-loader": "^1.0.0",
       "aurelia-logging": "^1.0.0",
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "aurelia-binding": "^1.7.1 || ^2.0.0",
+    "aurelia-binding": "^2.0.0",
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-loader": "^1.0.0",
     "aurelia-logging": "^1.0.0",


### PR DESCRIPTION
To be able to install via JSPM (which doesn't support comparator sets for versioning)

Note; got 1 failing specs test when running `karma start`:

> WARN [karma]: No captured browser, open http://localhost:9876/
> INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
> INFO [launcher]: Launching browser Chrome with unlimited concurrency
> INFO [launcher]: Starting browser Chrome
> INFO [Chrome 67.0.3396 (Windows 10.0.0)]: Connected on socket yUqp7kio-lw108VOAAAA with id 98606910
> Chrome 67.0.3396 (Windows 10.0.0) instancesChanges and instancesMutated together handles  together correctly FAILED
>         RangeError: Maximum call stack size exceeded
>             at ViewCompiler._compileElement (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2691:70)
>             at ViewCompiler._compileNode (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2548:23)
>             at ViewCompiler._compileNode (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2570:33)
>             at ViewCompiler.compile (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2517:12)
>             at HtmlBehaviorResource.compile (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:3983:46)
>             at ViewCompiler._compileElement (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2824:40)
>             at ViewCompiler._compileNode (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2548:23)
>             at ViewCompiler._compileNode (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2570:33)
>             at ViewCompiler.compile (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:2517:12)
>             at HtmlBehaviorResource.compile (jspm_packages/npm/aurelia-templating@1.3.0/aurelia-templating.js:3983:46)
> Chrome 67.0.3396 (Windows 10.0.0): Executed 190 of 192 (1 FAILED) (skipped 2) (9.956 secs / 9.877 secs)