### PR TITLE
Fix/repeat one time

### DIFF
--- a/src/analyze-view-factory.js
+++ b/src/analyze-view-factory.js
@@ -9,7 +9,8 @@ function behaviorRequiresLifecycle(instruction) {
   let name = t.elementName !== null ? t.elementName : t.attributeName;
   return lifecycleOptionalBehaviors.indexOf(name) === -1 && (t.handlesAttached || t.handlesBind || t.handlesCreated || t.handlesDetached || t.handlesUnbind)
     || t.viewFactory && viewsRequireLifecycle(t.viewFactory)
-    || instruction.viewFactory && viewsRequireLifecycle(instruction.viewFactory);
+    || instruction.viewFactory && viewsRequireLifecycle(instruction.viewFactory)
+    || instruction.initiatedByBehavior;
 }
 
 function targetRequiresLifecycle(instruction) {

--- a/src/if-core.js
+++ b/src/if-core.js
@@ -1,3 +1,5 @@
+import { updateBindings } from './repeat-utilities';
+
 /**
 * For internal use only. May change without warning.
 */
@@ -18,6 +20,12 @@ export class IfCore {
     // Store parent bindingContext, so we can pass it down
     this.bindingContext = bindingContext;
     this.overrideContext = overrideContext;
+  }
+
+  updateOneTimeBindings() {
+    if (this.view && this.view.isBound) {
+      updateBindings(this.view);
+    }
   }
 
   unbind() {

--- a/src/repeat-utilities.js
+++ b/src/repeat-utilities.js
@@ -104,6 +104,28 @@ export function isOneTime(expression) {
 }
 
 /**
+* Forces all one-time bindings in that view to reevaluate.
+*/
+export function updateBindings(view) {
+  let j = view.bindings.length;
+  while (j--) {
+    updateOneTimeBinding(view.bindings[j]);
+  }
+  j = view.controllers.length;
+  while (j--) {
+    let k = view.controllers[j].boundProperties.length;
+    while (k--) {
+      if (view.controllers[j].viewModel && view.controllers[j].viewModel.updateOneTimeBindings) {
+        view.controllers[j].viewModel.updateOneTimeBindings();
+      }
+      let binding = view.controllers[j].boundProperties[k].binding;
+      updateOneTimeBinding(binding);
+    }
+  }
+}
+
+
+/**
 * Forces a binding instance to reevaluate.
 */
 export function updateOneTimeBinding(binding) {

--- a/src/repeat.js
+++ b/src/repeat.js
@@ -15,7 +15,7 @@ import {
   getItemsSourceExpression,
   unwrapExpression,
   isOneTime,
-  updateOneTimeBinding
+  updateBindings
 } from './repeat-utilities';
 import {viewsRequireLifecycle} from './analyze-view-factory';
 import {AbstractRepeater} from './abstract-repeater';
@@ -270,17 +270,6 @@ export class Repeat extends AbstractRepeater {
   }
 
   updateBindings(view: View) {
-    let j = view.bindings.length;
-    while (j--) {
-      updateOneTimeBinding(view.bindings[j]);
-    }
-    j = view.controllers.length;
-    while (j--) {
-      let k = view.controllers[j].boundProperties.length;
-      while (k--) {
-        let binding = view.controllers[j].boundProperties[k].binding;
-        updateOneTimeBinding(binding);
-      }
-    }
+    updateBindings(view);
   }
 }


### PR DESCRIPTION
This is a crude attempt of fixing #356.

The fix for the `if` case was relatively straight-forward. But to disable the fast-pass for the "subview without lifecycle methods" case, I had to rely on `instruction.initiatedByBehavior`, because I couldn't find a better indicator.

I just started working with Aurelia a few weeks ago, so I’m sure there’s a more elegant way that I couldn’t discover. Let me know what you think!