### PR TITLE
Ability to turn of caching of view instance when using if

### DIFF
--- a/src/if-core.js
+++ b/src/if-core.js
@@ -12,6 +12,7 @@ export class IfCore {
     // state anymore, so we use `showing` for that.
     // Eventually, `showing` and `value` should be consistent.
     this.showing = false;
+    this.cache = true;
   }
 
   bind(bindingContext, overrideContext) {
@@ -67,7 +68,7 @@ export class IfCore {
     return this.viewSlot.add(this.view); // Promise or void
   }
 
-  _hide(cacheView = true) {
+  _hide() {
     if (!this.showing) {
       return;
     }
@@ -77,17 +78,15 @@ export class IfCore {
 
     if (removed instanceof Promise) {
       return removed.then(() => {
-        this._unbindView(cacheView);
+        this._unbindView();
       });
     } else {
-      this._unbindView(cacheView);
+      this._unbindView();
     }
   }
 
-  _unbindView(cache = true) {
-    if (cache === 'false') {
-      cache = false;
-    }
+  _unbindView() {
+    const cache = this.cache === 'false' ? false : !!this.cache;
     this.view.unbind();
     if (!cache) {
       this.view = null;

--- a/src/if-core.js
+++ b/src/if-core.js
@@ -67,7 +67,7 @@ export class IfCore {
     return this.viewSlot.add(this.view); // Promise or void
   }
 
-  _hide() {
+  _hide(cacheView = true) {
     if (!this.showing) {
       return;
     }
@@ -76,9 +76,17 @@ export class IfCore {
     let removed = this.viewSlot.remove(this.view); // Promise or View
 
     if (removed instanceof Promise) {
-      return removed.then(() => this.view.unbind());
+      return removed.then(() => {
+        this.view.unbind();
+        if (!cacheView) {
+          this.view = null;
+        }
+      });
+    } else {
+      this.view.unbind();
+      if (!cacheView) {
+        this.view = null;
+      }
     }
-
-    this.view.unbind();
   }
 }

--- a/src/if-core.js
+++ b/src/if-core.js
@@ -77,16 +77,20 @@ export class IfCore {
 
     if (removed instanceof Promise) {
       return removed.then(() => {
-        this.view.unbind();
-        if (!cacheView) {
-          this.view = null;
-        }
+        this._unbindView(cacheView);
       });
     } else {
-      this.view.unbind();
-      if (!cacheView) {
-        this.view = null;
-      }
+      this._unbindView(cacheView);
+    }
+  }
+
+  _unbindView(cache = true) {
+    if (cache === 'false') {
+      cache = false;
+    }
+    this.view.unbind();
+    if (!cache) {
+      this.view = null;
     }
   }
 }

--- a/src/if.js
+++ b/src/if.js
@@ -12,7 +12,7 @@ import {IfCore} from './if-core';
 export class If extends IfCore {
   @bindable({ primaryProperty: true }) condition: any;
   @bindable swapOrder: "before"|"with"|"after";
-  @bindable cache: boolean = true;
+  @bindable cache: boolean|string = true;
 
   /**
   * Binds the if to the binding context and override context
@@ -24,7 +24,7 @@ export class If extends IfCore {
     if (this.condition) {
       this._show();
     } else {
-      this._hide(this.cache);
+      this._hide();
     }
   }
 
@@ -45,7 +45,7 @@ export class If extends IfCore {
     if (this.elseVm) {
       promise = show ? this._swap(this.elseVm, this) : this._swap(this, this.elseVm);
     } else {
-      promise = show ? this._show() : this._hide(this.cache);
+      promise = show ? this._show() : this._hide();
     }
 
     if (promise) {
@@ -62,11 +62,11 @@ export class If extends IfCore {
   _swap(remove, add) {
     switch (this.swapOrder) {
     case 'before':
-      return Promise.resolve(add._show()).then(() => remove._hide(this.cache));
+      return Promise.resolve(add._show()).then(() => remove._hide());
     case 'with':
-      return Promise.all([ remove._hide(this.cache), add._show() ]);
+      return Promise.all([ remove._hide(), add._show() ]);
     default:  // "after", default and unknown values
-      let promise = remove._hide(this.cache);
+      let promise = remove._hide();
       return promise ? promise.then(() => add._show()) : add._show();
     }
   }

--- a/src/if.js
+++ b/src/if.js
@@ -12,6 +12,7 @@ import {IfCore} from './if-core';
 export class If extends IfCore {
   @bindable({ primaryProperty: true }) condition: any;
   @bindable swapOrder: "before"|"with"|"after";
+  @bindable cache: boolean = true;
 
   /**
   * Binds the if to the binding context and override context
@@ -23,7 +24,7 @@ export class If extends IfCore {
     if (this.condition) {
       this._show();
     } else {
-      this._hide();
+      this._hide(this.cache);
     }
   }
 
@@ -44,7 +45,7 @@ export class If extends IfCore {
     if (this.elseVm) {
       promise = show ? this._swap(this.elseVm, this) : this._swap(this, this.elseVm);
     } else {
-      promise = show ? this._show() : this._hide();
+      promise = show ? this._show() : this._hide(this.cache);
     }
 
     if (promise) {
@@ -61,11 +62,11 @@ export class If extends IfCore {
   _swap(remove, add) {
     switch (this.swapOrder) {
     case 'before':
-      return Promise.resolve(add._show()).then(() => remove._hide());
+      return Promise.resolve(add._show()).then(() => remove._hide(this.cache));
     case 'with':
-      return Promise.all([ remove._hide(), add._show() ]);
+      return Promise.all([ remove._hide(this.cache), add._show() ]);
     default:  // "after", default and unknown values
-      let promise = remove._hide();
+      let promise = remove._hide(this.cache);
       return promise ? promise.then(() => add._show()) : add._show();
     }
   }

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -172,6 +172,24 @@ describe('if', () => {
     expect(sut.view).toBeNull();
   });
 
+  it('should set the view instance to null after correctly unbound when caching is turned off by string "false"', () => {
+    sut.condition = false;
+    sut.showing = true;
+    const view = {isBound: false, unbind: jasmine.createSpy('unbind')};
+    sut.view = view;
+    sut.cache = 'false';
+    let bindingContext = 42;
+    let overrideContext = 24;
+
+    spyOn(sut, '_hide').and.callThrough();
+
+    sut.bind(bindingContext, overrideContext);
+
+    expect(sut._hide).toHaveBeenCalled();
+    expect(view.unbind).toHaveBeenCalled();
+    expect(sut.view).toBeNull();
+  });
+
   it('should show the view when provided value is truthy and currently not showing', () => {
     sut.showing = false;
     sut.view = new ViewMock();

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -154,6 +154,24 @@ describe('if', () => {
     expect(sut.view.unbind).toHaveBeenCalled();
   });
 
+  it('should set the view instance to null after correctly unbound when caching is turned off', () => {
+    sut.condition = false;
+    sut.showing = true;
+    const view = {isBound: false, unbind: jasmine.createSpy('unbind')};
+    sut.view = view;
+    sut.cache = false;
+    let bindingContext = 42;
+    let overrideContext = 24;
+
+    spyOn(sut, '_hide').and.callThrough();
+
+    sut.bind(bindingContext, overrideContext);
+
+    expect(sut._hide).toHaveBeenCalled();
+    expect(view.unbind).toHaveBeenCalled();
+    expect(sut.view).toBeNull();
+  });
+
   it('should show the view when provided value is truthy and currently not showing', () => {
     sut.showing = false;
     sut.view = new ViewMock();


### PR DESCRIPTION
fix #320 

I believe the syntax of this `if` is:

```html
if="condition.bind: someValue; cache: false"
```

Don't know if the CI fail is due to my changes. All seems good locally.