### PR TITLE
Update repeat.js

### DIFF
--- a/src/repeat.js
+++ b/src/repeat.js
@@ -221,7 +221,7 @@ export class Repeat extends AbstractRepeater {
       for (let i = 0; i < instructionIds.length; i++) {
         const expressions = instructions[instructionIds[i]].expressions;
         if (expressions) {
-          for (let ii = 0; i < expressions.length; i++) {
+          for (let ii = 0; ii < expressions.length; ii++) {
             if (expressions[ii].targetProperty === 'matcher') {
               const matcherBinding = expressions[ii];
               expressions.splice(ii, 1);


### PR DESCRIPTION
fix(templating-resources): change indexer in repeat.js(_captureAndRemoveMatcherBinding)

the inner for-loop uses the indexer of the outer for-loop which is incorrect

breaking changes: None
