### PR TITLE
fix(typings): explicit return typings for createFullOverrideContext

### DIFF
--- a/src/repeat-utilities.ts
+++ b/src/repeat-utilities.ts
@@ -3,7 +3,8 @@ import {
   BindingBehavior,
   ValueConverter,
   sourceContext,
-  bindingMode
+  bindingMode,
+  OverrideContext
 } from 'aurelia-binding';
 
 const oneTime = bindingMode.oneTime;
@@ -31,7 +32,7 @@ export function updateOverrideContexts(views, startIndex) {
  * @param length The collections total length.
  * @param key The key in a key/value pair.
  */
-export function createFullOverrideContext(repeat, data, index, length, key?: string) {
+export function createFullOverrideContext(repeat, data, index, length, key?: string): OverrideContext {
   let bindingContext = {};
   let overrideContext = createOverrideContext(bindingContext, repeat.scope.overrideContext);
   // is key/value pair (Map)


### PR DESCRIPTION
Thanks to @veyselozdemir for discovering this.

Explicitly type `createOverrideContext` to support lower version of TS

@EisenbergEffect 

close #375 