### PR TITLE
feat(compose): bindable activation-strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-templating-resources",
-  "version": "1.9.1",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3504,7 +3504,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3525,12 +3526,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3545,17 +3548,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3672,7 +3678,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3684,6 +3691,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3698,6 +3706,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3705,12 +3714,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3729,6 +3740,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3809,7 +3821,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3821,6 +3834,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3906,7 +3920,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3942,6 +3957,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3961,6 +3977,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4004,12 +4021,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -3,7 +3,22 @@ import { DOM } from 'aurelia-pal';
 import { TaskQueue } from 'aurelia-task-queue';
 import { bindable, CompositionContext, CompositionEngine, customElement, noView, View, ViewResources, ViewSlot } from 'aurelia-templating';
 
-
+/**
+ * Available activation strategies for the view and view-model bound to compose
+ *
+ * @export
+ * @enum {string}
+ */
+export enum ActivationStrategy {
+  /**
+   * Default activation strategy; the 'activate' lifecycle hook will be invoked when the model changes.
+   */
+  InvokeLifecycle = 'invoke-lifecycle',
+  /**
+   * The view/view-model will be recreated, when the "model" changes.
+   */
+  Replace = 'replace'
+}
 
 /**
  * Used to compose a new view / view-model template or bind to an existing instance.
@@ -38,6 +53,15 @@ export class Compose {
    * @type {Class}
    */
   @bindable viewModel: any;
+
+  /**
+   * Strategy to activate the view-model. Default is "invoke-lifecycle".
+   * Bind "replace" to recreate the view/view-model when the model changes.
+   *
+   * @property activationStrategy
+   * @type {ActivationStrategy}
+   */
+  @bindable activationStrategy: ActivationStrategy = ActivationStrategy.InvokeLifecycle;
 
   /**
    * SwapOrder to control the swapping order of the custom element's view.
@@ -226,7 +250,7 @@ function processChanges(composer: Compose) {
   const changes = composer.changes;
   composer.changes = Object.create(null);
 
-  if (!('view' in changes) && !('viewModel' in changes) && ('model' in changes)) {
+  if (!('view' in changes) && !('viewModel' in changes) && ('model' in changes) && composer.activationStrategy !== ActivationStrategy.Replace) {
     // just try to activate the current view model
     composer.pendingTask = tryActivateViewModel(composer.currentViewModel, changes.model);
     if (!composer.pendingTask) { return; }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -250,7 +250,7 @@ function processChanges(composer: Compose) {
   const changes = composer.changes;
   composer.changes = Object.create(null);
 
-  if (!('view' in changes) && !('viewModel' in changes) && ('model' in changes) && composer.activationStrategy !== ActivationStrategy.Replace) {
+  if (!('view' in changes) && !('viewModel' in changes) && ('model' in changes) && determineActivationStrategy(composer) !== ActivationStrategy.Replace) {
     // just try to activate the current view model
     composer.pendingTask = tryActivateViewModel(composer.currentViewModel, changes.model);
     if (!composer.pendingTask) { return; }
@@ -297,4 +297,13 @@ function requestUpdate(composer: Compose) {
     composer.updateRequested = false;
     processChanges(composer);
   });
+}
+
+function determineActivationStrategy(composer: Compose) {
+  let activationStrategy = composer.activationStrategy;
+  const vm = composer.currentViewModel;
+  if (vm && typeof vm.determineActivationStrategy === 'function') {
+    activationStrategy = vm.determineActivationStrategy();
+  }
+  return activationStrategy;
 }

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { TaskQueue } from 'aurelia-task-queue';
-import { Compose } from '../src/compose';
+import { Compose, ActivationStrategy } from '../src/compose';
 import * as LogManager from 'aurelia-logging';
 import { View } from 'aurelia-framework';
 
@@ -153,6 +153,17 @@ describe('Compose', () => {
       taskQueue.queueMicroTask(() => {
         expect(compositionEngineMock.compose).toHaveBeenCalledTimes(1);
         expect(compositionEngineMock.compose).toHaveBeenCalledWith(jasmine.objectContaining({ view }));
+        done();
+      });
+    });
+
+    it('when "model" changes and the activation-strategy is set to "replace"', done => {
+      const model = {};
+      sut.activationStrategy = ActivationStrategy.Replace;
+      updateBindable('model', model);
+      taskQueue.queueMicroTask(() => {
+        expect(compositionEngineMock.compose).toHaveBeenCalledTimes(1);
+        expect(compositionEngineMock.compose).toHaveBeenCalledWith(jasmine.objectContaining({ model }));
         done();
       });
     });

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -213,6 +213,16 @@ describe('Compose', () => {
         done();
       });
     });
+
+    it('when "model" changes and the activation-strategy is set to unknown value', done => {
+      const model = {};
+      sut.activationStrategy = Math.random().toString() as ActivationStrategy;
+      updateBindable('model', model);
+      taskQueue.queueMicroTask(() => {
+        expect(compositionEngineMock.compose).not.toHaveBeenCalled();
+        done();
+      });
+    });
   });
 
   it('aggregates changes from single drain of the micro task queue', done => {
@@ -245,6 +255,19 @@ describe('Compose', () => {
     });
 
     it('activates the "currentViewModel" if there is no change requiring composition', done => {
+      const model = 42;
+      sut.activationStrategy = Math.random().toString() as ActivationStrategy;
+      sut.currentViewModel = jasmine.createSpyObj('currentViewModelSpy', ['activate']);
+      updateBindable('model', model);
+      taskQueue.queueMicroTask(() => {
+        expect(compositionEngineMock.compose).not.toHaveBeenCalled();
+        expect(sut.currentViewModel.activate).toHaveBeenCalledTimes(1);
+        expect(sut.currentViewModel.activate).toHaveBeenCalledWith(model);
+        done();
+      });
+    });
+
+    it('activates the "currentViewModel" if the activation strategy is unknown', done => {
       const model = 42;
       sut.currentViewModel = jasmine.createSpyObj('currentViewModelSpy', ['activate']);
       updateBindable('model', model);

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -167,12 +167,47 @@ describe('Compose', () => {
         done();
       });
     });
+
+    it('when "model" changes and the "determineActivationStrategy" hook in view-model returns "replace"', done => {
+      const model = {};
+      sut.currentViewModel = {
+        determineActivationStrategy() { return ActivationStrategy.Replace; }
+      };
+      updateBindable('model', model);
+      taskQueue.queueMicroTask(() => {
+        expect(compositionEngineMock.compose).toHaveBeenCalledTimes(1);
+        expect(compositionEngineMock.compose).toHaveBeenCalledWith(jasmine.objectContaining({ model }));
+        done();
+      });
+    });
   });
 
   describe('does not trigger composition', () => {
     it('when only "model" or "swapOrder" change', done => {
       updateBindable('model', {});
       updateBindable('swapOrder', 'after');
+      taskQueue.queueMicroTask(() => {
+        expect(compositionEngineMock.compose).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('when "model" changes and the "determineActivationStrategy" hook in view-model returns "invoke-lifecycle"', done => {
+      const model = {};
+      sut.currentViewModel = {
+        determineActivationStrategy() { return ActivationStrategy.InvokeLifecycle; }
+      };
+      updateBindable('model', model);
+      taskQueue.queueMicroTask(() => {
+        expect(compositionEngineMock.compose).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('when "model" changes and the "determineActivationStrategy" hook is not implemented in view-model', done => {
+      const model = {};
+      sut.currentViewModel = {};
+      updateBindable('model', model);
       taskQueue.queueMicroTask(() => {
         expect(compositionEngineMock.compose).not.toHaveBeenCalled();
         done();


### PR DESCRIPTION
This PR introduces bindable activation-strategy for compose. The default strategy is 'invoke-lifecycle', which is also the current strategy. The strategy 'replace' forces re-creation of bound view and view-model on model change.

Fixes #381