### PR TITLE
Allow pug file extensions in html-resource-plugin

### DIFF
--- a/src/html-resource-plugin.ts
+++ b/src/html-resource-plugin.ts
@@ -1,30 +1,35 @@
 import {ViewEngine} from 'aurelia-templating';
 import {_createDynamicElement} from './dynamic-element';
 
+const VIEW_EXTENSIONS = ['html', 'jade', 'pug'];
+const VIEW_REGEXP = new RegExp('([^\\/^\\?]+)\\.(' + VIEW_EXTENSIONS.join('|') + ')', 'i');
+
 export function getElementName(address) {
-  return /([^\/^\?]+)\.html/i.exec(address)[1].toLowerCase();
+  return VIEW_REGEXP.exec(address)[1].toLowerCase();
 }
 
 export function configure(config) {
   const viewEngine = config.container.get(ViewEngine);
   const loader = config.aurelia.loader;
+  
+  const fetch = function(viewUrl) {
+    return loader.loadTemplate(viewUrl).then(registryEntry => {
+      let bindableNames = registryEntry.template.getAttribute('bindable');
+      const useShadowDOMmode: null | '' | 'open' | 'closed' = registryEntry.template.getAttribute('use-shadow-dom');
+      const name = getElementName(viewUrl);
 
-  viewEngine.addResourcePlugin('.html', {
-    'fetch': function(viewUrl) {
-      return loader.loadTemplate(viewUrl).then(registryEntry => {
-        let bindableNames = registryEntry.template.getAttribute('bindable');
-        const useShadowDOMmode: null | '' | 'open' | 'closed' = registryEntry.template.getAttribute('use-shadow-dom');
-        const name = getElementName(viewUrl);
+      if (bindableNames) {
+        bindableNames = bindableNames.split(',').map(x => x.trim());
+        registryEntry.template.removeAttribute('bindable');
+      } else {
+        bindableNames = [];
+      }
 
-        if (bindableNames) {
-          bindableNames = bindableNames.split(',').map(x => x.trim());
-          registryEntry.template.removeAttribute('bindable');
-        } else {
-          bindableNames = [];
-        }
-
-        return { [name]: _createDynamicElement({name, viewUrl, bindableNames, useShadowDOMmode}) };
-      });
-    }
-  });
+      return { [name]: _createDynamicElement({name, viewUrl, bindableNames, useShadowDOMmode}) };
+    });
+  };
+  
+  for (const ext of VIEW_EXTENSIONS) {
+    viewEngine.addResourcePlugin('.' + ext, {fetch};
+  }
 }


### PR DESCRIPTION
I'm using pug & webpack and found out that
```html
<require from="resources/elements/simple-component.pug"></require>
```
was not working.

After looking into the codebase I found out that this seems to fix the issue though I'm not sure it's the proper way to do this.

Ideally I would have loved to find a way to make this configurable in `main.js` and even the webpack aurelia plugin `viewExtensions` option to be included in environment and looked for by the generated `main.js` file. Maybe with something like :

```js
export function configure(aurelia) {
  aurelia.use
    .standardConfiguration()
    .plugin(PLATFORM.moduleName('aurelia-validation'))
    .plugin(PLATFORM.moduleName('aurelia-animator-css'))
    .feature(PLATFORM.moduleName('resources/index'))
  ;

  if (environment.viewExtensions) {
    aurelia.setViewExtensions(environment.viewExtensions);
  }
}
```

But it's too big a change for me at this point. And I think it would have impacts cross repositories so it's better to get things done by smaller steps I suppose.

Hope this helps!